### PR TITLE
Turtlebot3Fake::init() should be invoked regardless ROS_ASSERT_ENABLED is defined.

### DIFF
--- a/turtlebot3_fake/src/turtlebot3_fake.cpp
+++ b/turtlebot3_fake/src/turtlebot3_fake.cpp
@@ -22,7 +22,8 @@ Turtlebot3Fake::Turtlebot3Fake()
 : nh_priv_("~")
 {
   //Init fake turtlebot node
-  ROS_ASSERT(init());
+  bool init_result = init();
+  ROS_ASSERT(init_result);
 }
 
 Turtlebot3Fake::~Turtlebot3Fake()


### PR DESCRIPTION
ROS_ASSERT could be no-op if it not ROS_ASSERT_ENABLED. Therefore, init() won't not be invoked under this condition. Suggest to rearrange the logic here.