### PR TITLE
Remove unneeded plugin_path from gazebo_ros export

### DIFF
--- a/turtlebot3_gazebo/package.xml
+++ b/turtlebot3_gazebo/package.xml
@@ -25,6 +25,6 @@
   <depend>gazebo_ros</depend>
   <exec_depend>gazebo</exec_depend>
   <export>
-    <gazebo_ros plugin_path="${prefix}/lib:${prefix}/models/turtlebot3_autorace/gazebo_traffic_plugin" gazebo_media_path="${prefix}" gazebo_model_path="${prefix}/models:${prefix}/models/turtlebot3_autorace"/>
+    <gazebo_ros gazebo_media_path="${prefix}" gazebo_model_path="${prefix}/models:${prefix}/models/turtlebot3_autorace"/>
   </export>
 </package>


### PR DESCRIPTION
While investigating https://bitbucket.org/osrf/gazebo_tutorials/pull-requests/539, I discovered that this package does not actually contain any Gazebo plugins anymore, and therefore does not need to export `plugin_path` for `gazebo_ros` in `package.xml`.