### PR TITLE
[ros2 dashing] remove now obsolete process to set use_sim_time

### DIFF
--- a/turtlebot3_gazebo/launch/turtlebot3_world.launch.py
+++ b/turtlebot3_gazebo/launch/turtlebot3_world.launch.py
@@ -39,10 +39,6 @@ def generate_launch_description():
             cmd=['gazebo', '--verbose', world, '-s', 'libgazebo_ros_init.so'],
             output='screen'),
 
-        ExecuteProcess(
-            cmd=['ros2', 'param', 'set', '/gazebo', 'use_sim_time', use_sim_time],
-            output='screen'),
-
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource([launch_file_dir, '/turtlebot3_state_publisher.launch.py']),
             launch_arguments={'use_sim_time': use_sim_time}.items(),


### PR DESCRIPTION
In ROS2 Dashing, gazebo_ros_init sets the `use_sim_time` parameter to true by default. It also sets it for each ROS nodes that will be created by gazebo ros plugins.
Removing this command allow to run turtlebot3 simulation with SROS2 more easily as it removes a node with an "unknown" node name.

Note: This change is not backward compatible with ROS 2 Crystal, so if this branch targets both crystal and dashing, this PR should be declined / postponed.

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>