### PR TITLE
[eloquent] use remapping tag in urdf/sdf

### DIFF
--- a/turtlebot3_gazebo/models/turtlebot3_burger/model-1_4.sdf
+++ b/turtlebot3_gazebo/models/turtlebot3_burger/model-1_4.sdf
@@ -89,7 +89,7 @@
         <plugin name="turtlebot3_imu" filename="libgazebo_ros_imu_sensor.so">
           <ros>
             <!-- <namespace>/tb3</namespace> -->
-            <argument>~/out:=imu</argument>
+            <remapping>~/out:=imu</remapping>
           </ros>
         </plugin>
       </sensor>
@@ -157,7 +157,7 @@
         <plugin name="turtlebot3_laserscan" filename="libgazebo_ros_ray_sensor.so">
           <ros>
             <!-- <namespace>/tb3</namespace> -->
-            <argument>~/out:=scan</argument>
+            <remapping>~/out:=scan</remapping>
           </ros>
           <output_type>sensor_msgs/LaserScan</output_type>
           <frame_name>base_scan</frame_name>
@@ -398,7 +398,7 @@
     <plugin name="turtlebot3_joint_state" filename="libgazebo_ros_joint_state_publisher.so">
       <ros>
         <!-- <namespace>/tb3</namespace> -->
-        <argument>~/out:=joint_states</argument>
+        <remapping>~/out:=joint_states</remapping>
       </ros>
       <update_rate>30</update_rate>
       <joint_name>wheel_left_joint</joint_name>

--- a/turtlebot3_gazebo/models/turtlebot3_burger/model.sdf
+++ b/turtlebot3_gazebo/models/turtlebot3_burger/model.sdf
@@ -89,7 +89,7 @@
         <plugin name="turtlebot3_imu" filename="libgazebo_ros_imu_sensor.so">
           <ros>
             <!-- <namespace>/tb3</namespace> -->
-            <argument>~/out:=imu</argument>
+            <remapping>~/out:=imu</remapping>
           </ros>
         </plugin>
       </sensor>
@@ -157,7 +157,7 @@
         <plugin name="turtlebot3_laserscan" filename="libgazebo_ros_ray_sensor.so">
           <ros>
             <!-- <namespace>/tb3</namespace> -->
-            <argument>~/out:=scan</argument>
+            <remapping>~/out:=scan</remapping>
           </ros>
           <output_type>sensor_msgs/LaserScan</output_type>
           <frame_name>base_scan</frame_name>
@@ -398,7 +398,7 @@
     <plugin name="turtlebot3_joint_state" filename="libgazebo_ros_joint_state_publisher.so">
       <ros>
         <!-- <namespace>/tb3</namespace> -->
-        <argument>~/out:=joint_states</argument>
+        <remapping>~/out:=joint_states</remapping>
       </ros>
       <update_rate>30</update_rate>
       <joint_name>wheel_left_joint</joint_name>

--- a/turtlebot3_gazebo/models/turtlebot3_waffle/model-1_4.sdf
+++ b/turtlebot3_gazebo/models/turtlebot3_waffle/model-1_4.sdf
@@ -89,7 +89,7 @@
         <plugin name="turtlebot3_imu" filename="libgazebo_ros_imu_sensor.so">
           <ros>
             <!-- <namespace>/tb3</namespace> -->
-            <argument>~/out:=imu</argument>
+            <remapping>~/out:=imu</remapping>
           </ros>
         </plugin>
       </sensor>
@@ -157,7 +157,7 @@
         <plugin name="turtlebot3_laserscan" filename="libgazebo_ros_ray_sensor.so">
           <ros>
             <!-- <namespace>/tb3</namespace> -->
-            <argument>~/out:=scan</argument>
+            <remapping>~/out:=scan</remapping>
           </ros>
           <output_type>sensor_msgs/LaserScan</output_type>
           <frame_name>base_scan</frame_name>
@@ -401,8 +401,8 @@
           <plugin name="camera_driver" filename="libgazebo_ros_camera.so">
             <ros>
               <!-- <namespace>test_cam</namespace> -->
-              <!-- <argument>image_raw:=image_demo</argument> -->
-              <!-- <argument>camera_info:=camera_info_demo</argument> -->
+              <!-- <remapping>image_raw:=image_demo</remapping> -->
+              <!-- <remapping>camera_info:=camera_info_demo</remapping> -->
             </ros>
             <!-- camera_name>omit so it defaults to sensor name</camera_name-->
             <!-- frame_name>omit so it defaults to link name</frameName-->
@@ -508,7 +508,7 @@
     <plugin name="turtlebot3_joint_state" filename="libgazebo_ros_joint_state_publisher.so">
       <ros>
         <!-- <namespace>/tb3</namespace> -->
-        <argument>~/out:=joint_states</argument>
+        <remapping>~/out:=joint_states</remapping>
       </ros>
       <update_rate>30</update_rate>
       <joint_name>wheel_left_joint</joint_name>

--- a/turtlebot3_gazebo/models/turtlebot3_waffle/model.sdf
+++ b/turtlebot3_gazebo/models/turtlebot3_waffle/model.sdf
@@ -89,7 +89,7 @@
         <plugin name="turtlebot3_imu" filename="libgazebo_ros_imu_sensor.so">
           <ros>
             <!-- <namespace>/tb3</namespace> -->
-            <argument>~/out:=imu</argument>
+            <remapping>~/out:=imu</remapping>
           </ros>
         </plugin>
       </sensor>
@@ -157,7 +157,7 @@
         <plugin name="turtlebot3_laserscan" filename="libgazebo_ros_ray_sensor.so">
           <ros>
             <!-- <namespace>/tb3</namespace> -->
-            <argument>~/out:=scan</argument>
+            <remapping>~/out:=scan</remapping>
           </ros>
           <output_type>sensor_msgs/LaserScan</output_type>
           <frame_name>base_scan</frame_name>
@@ -401,8 +401,8 @@
           <plugin name="camera_driver" filename="libgazebo_ros_camera.so">
             <ros>
               <!-- <namespace>test_cam</namespace> -->
-              <!-- <argument>image_raw:=image_demo</argument> -->
-              <!-- <argument>camera_info:=camera_info_demo</argument> -->
+              <!-- <remapping>image_raw:=image_demo</remapping> -->
+              <!-- <remapping>camera_info:=camera_info_demo</remapping> -->
             </ros>
             <!-- camera_name>omit so it defaults to sensor name</camera_name-->
             <!-- frame_name>omit so it defaults to link name</frameName-->
@@ -508,7 +508,7 @@
     <plugin name="turtlebot3_joint_state" filename="libgazebo_ros_joint_state_publisher.so">
       <ros>
         <!-- <namespace>/tb3</namespace> -->
-        <argument>~/out:=joint_states</argument>
+        <remapping>~/out:=joint_states</remapping>
       </ros>
       <update_rate>30</update_rate>
       <joint_name>wheel_left_joint</joint_name>

--- a/turtlebot3_gazebo/models/turtlebot3_waffle_pi/model-1_4.sdf
+++ b/turtlebot3_gazebo/models/turtlebot3_waffle_pi/model-1_4.sdf
@@ -89,7 +89,7 @@
         <plugin name="turtlebot3_imu" filename="libgazebo_ros_imu_sensor.so">
           <ros>
             <!-- <namespace>/tb3</namespace> -->
-            <argument>~/out:=imu</argument>
+            <remapping>~/out:=imu</remapping>
           </ros>
         </plugin>
       </sensor>
@@ -157,7 +157,7 @@
         <plugin name="turtlebot3_laserscan" filename="libgazebo_ros_ray_sensor.so">
           <ros>
             <!-- <namespace>/tb3</namespace> -->
-            <argument>~/out:=scan</argument>
+            <remapping>~/out:=scan</remapping>
           </ros>
           <output_type>sensor_msgs/LaserScan</output_type>
           <frame_name>base_scan</frame_name>
@@ -401,8 +401,8 @@
           <plugin name="camera_driver" filename="libgazebo_ros_camera.so">
             <ros>
               <!-- <namespace>test_cam</namespace> -->
-              <!-- <argument>image_raw:=image_demo</argument> -->
-              <!-- <argument>camera_info:=camera_info_demo</argument> -->
+              <!-- <remapping>image_raw:=image_demo</remapping> -->
+              <!-- <remapping>camera_info:=camera_info_demo</remapping> -->
             </ros>
             <!-- camera_name>omit so it defaults to sensor name</camera_name-->
             <!-- frame_name>omit so it defaults to link name</frameName-->
@@ -508,7 +508,7 @@
     <plugin name="turtlebot3_joint_state" filename="libgazebo_ros_joint_state_publisher.so">
       <ros>
         <!-- <namespace>/tb3</namespace> -->
-        <argument>~/out:=joint_states</argument>
+        <remapping>~/out:=joint_states</remapping>
       </ros>
       <update_rate>30</update_rate>
       <joint_name>wheel_left_joint</joint_name>

--- a/turtlebot3_gazebo/models/turtlebot3_waffle_pi/model.sdf
+++ b/turtlebot3_gazebo/models/turtlebot3_waffle_pi/model.sdf
@@ -89,7 +89,7 @@
         <plugin name="turtlebot3_imu" filename="libgazebo_ros_imu_sensor.so">
           <ros>
             <!-- <namespace>/tb3</namespace> -->
-            <argument>~/out:=imu</argument>
+            <remapping>~/out:=imu</remapping>
           </ros>
         </plugin>
       </sensor>
@@ -157,7 +157,7 @@
         <plugin name="turtlebot3_laserscan" filename="libgazebo_ros_ray_sensor.so">
           <ros>
             <!-- <namespace>/tb3</namespace> -->
-            <argument>~/out:=scan</argument>
+            <remapping>~/out:=scan</remapping>
           </ros>
           <output_type>sensor_msgs/LaserScan</output_type>
           <frame_name>base_scan</frame_name>
@@ -401,8 +401,8 @@
           <plugin name="camera_driver" filename="libgazebo_ros_camera.so">
             <ros>
               <!-- <namespace>test_cam</namespace> -->
-              <!-- <argument>image_raw:=image_demo</argument> -->
-              <!-- <argument>camera_info:=camera_info_demo</argument> -->
+              <!-- <remapping>image_raw:=image_demo</remapping> -->
+              <!-- <remapping>camera_info:=camera_info_demo</remapping> -->
             </ros>
             <!-- camera_name>omit so it defaults to sensor name</camera_name-->
             <!-- frame_name>omit so it defaults to link name</frameName-->
@@ -508,7 +508,7 @@
     <plugin name="turtlebot3_joint_state" filename="libgazebo_ros_joint_state_publisher.so">
       <ros>
         <!-- <namespace>/tb3</namespace> -->
-        <argument>~/out:=joint_states</argument>
+        <remapping>~/out:=joint_states</remapping>
       </ros>
       <update_rate>30</update_rate>
       <joint_name>wheel_left_joint</joint_name>


### PR DESCRIPTION
This is the result of a 
```
sed -i 's@argument>@remapping>@g' `grep -rl "<argument>"`
```
 This has been tested only on a simulated turtlebot3 burger

This fixes https://github.com/ROBOTIS-GIT/turtlebot3_simulations/issues/91 for eloquent allowing to get rid of the warnings
This change is NOT valid for ROS 2 dashing ATM