### PR TITLE
add turtlebot3_description to dependency list

### DIFF
--- a/turtlebot3_gazebo/package.xml
+++ b/turtlebot3_gazebo/package.xml
@@ -24,6 +24,7 @@
   <depend>tf</depend>
   <depend>gazebo_ros</depend>
   <exec_depend>gazebo</exec_depend>
+  <exec_depend>turtlebot3_description</exec_depend>
   <export>
     <gazebo_ros gazebo_media_path="${prefix}"/>
     <gazebo_ros gazebo_model_path="${prefix}/models"/>


### PR DESCRIPTION
Without it:

```
# apt install ros-melodic-turtlebot3-gazebo
# source /opt/ros/melodic/setup.bash
# export TURTLEBOT3_MODEL=waffle
# roslaunch turtlebot3_gazebo turtlebot3_world.launch

Resource not found: turtlebot3_description
ROS path [0]=/opt/ros/melodic/share/ros
ROS path [1]=/opt/ros/melodic/share
The traceback for the exception was written to the log file
```


