### PR TITLE
[turtlebot3_drive] Fix init() usage

### DIFF
--- a/turtlebot3_gazebo/src/turtlebot3_drive.cpp
+++ b/turtlebot3_gazebo/src/turtlebot3_drive.cpp
@@ -23,7 +23,8 @@ Turtlebot3Drive::Turtlebot3Drive()
 {
   //Init gazebo ros turtlebot3 node
   ROS_INFO("TurtleBot3 Simulation Node Init");
-  ROS_ASSERT(init());
+  auto ret = init();
+  ROS_ASSERT(ret);
 }
 
 Turtlebot3Drive::~Turtlebot3Drive()


### PR DESCRIPTION
Apply the same [fix](https://github.com/ROBOTIS-GIT/turtlebot3_simulations/pull/68) to turtlebot3_drive.