### PR TITLE
Automatically make the models available to gazebo_ros

### DIFF
--- a/turtlebot3_gazebo/package.xml
+++ b/turtlebot3_gazebo/package.xml
@@ -24,5 +24,6 @@
   <depend>turtlebot3</depend>
   <export>
     <build_type>ament_cmake</build_type>
+    <gazebo_ros gazebo_model_path="${prefix}/models"/>
   </export>
 </package>


### PR DESCRIPTION
By adding gazebo_model_path to the exports of this package, the models
directory will be automatically available if you are using
`gazebo.launch.py`.  This means that you don't need to set
GAZEBO_MODEL_PATH this in your .bashrc or in other places.

This was implemented in the ROS1 branch but the change was
somehow forgotten.

Also fix #123