### PR TITLE
waffle model is missing imu joint

### DIFF
--- a/turtlebot3_gazebo/models/turtlebot3_waffle/model-1_4.sdf
+++ b/turtlebot3_gazebo/models/turtlebot3_waffle/model-1_4.sdf
@@ -445,6 +445,15 @@
       <child>caster_back_left_link</child>
     </joint>
 
+    <joint name="imu_joint" type="fixed">
+      <parent>base_link</parent>
+      <child>imu_link</child>
+      <pose>-0.032 0 0.068 0 0 0</pose>
+      <axis>
+        <xyz>0 0 1</xyz>
+      </axis>
+    </joint>    
+
     <joint name="lidar_joint" type="fixed">
       <parent>base_link</parent>
       <child>base_scan</child>

--- a/turtlebot3_gazebo/models/turtlebot3_waffle/model.sdf
+++ b/turtlebot3_gazebo/models/turtlebot3_waffle/model.sdf
@@ -445,6 +445,15 @@
       <child>caster_back_left_link</child>
     </joint>
 
+    <joint name="imu_joint" type="fixed">
+      <parent>base_link</parent>
+      <child>imu_link</child>
+      <pose>-0.032 0 0.068 0 0 0</pose>
+      <axis>
+        <xyz>0 0 1</xyz>
+      </axis>
+    </joint>    
+
     <joint name="lidar_joint" type="fixed">
       <parent>base_link</parent>
       <child>base_scan</child>

--- a/turtlebot3_gazebo/models/turtlebot3_waffle_pi/model-1_4.sdf
+++ b/turtlebot3_gazebo/models/turtlebot3_waffle_pi/model-1_4.sdf
@@ -445,6 +445,15 @@
       <child>caster_back_left_link</child>
     </joint>
 
+    <joint name="imu_joint" type="fixed">
+      <parent>base_link</parent>
+      <child>imu_link</child>
+      <pose>-0.032 0 0.068 0 0 0</pose>
+      <axis>
+        <xyz>0 0 1</xyz>
+      </axis>
+    </joint>    
+
     <joint name="lidar_joint" type="fixed">
       <parent>base_link</parent>
       <child>base_scan</child>

--- a/turtlebot3_gazebo/models/turtlebot3_waffle_pi/model.sdf
+++ b/turtlebot3_gazebo/models/turtlebot3_waffle_pi/model.sdf
@@ -445,6 +445,15 @@
       <child>caster_back_left_link</child>
     </joint>
 
+    <joint name="imu_joint" type="fixed">
+      <parent>base_link</parent>
+      <child>imu_link</child>
+      <pose>-0.032 0 0.068 0 0 0</pose>
+      <axis>
+        <xyz>0 0 1</xyz>
+      </axis>
+    </joint>    
+
     <joint name="lidar_joint" type="fixed">
       <parent>base_link</parent>
       <child>base_scan</child>


### PR DESCRIPTION
I think that sdf of waffle model is missing imu joint,
When I running cartographer at gazebo simulation by waffle model , I see odom unstable and the map is badly twisted.
I think one of the causes is imu joint missing . :)
Thank you for your review.