### PR TITLE
replace 'xacro.py' with 'xacro --inorder'

### DIFF
--- a/turtlebot3_gazebo/launch/turtlebot3_stage_1.launch
+++ b/turtlebot3_gazebo/launch/turtlebot3_stage_1.launch
@@ -14,7 +14,7 @@
   </include>  
 
 
-  <param name="robot_description" command="$(find xacro)/xacro.py $(find turtlebot3_description)/urdf/turtlebot3_$(arg model).urdf.xacro" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder $(find turtlebot3_description)/urdf/turtlebot3_$(arg model).urdf.xacro" />
 
   <node name="spawn_urdf" pkg="gazebo_ros" type="spawn_model" args="-urdf -model turtlebot3_burger -x $(arg x_pos) -y $(arg y_pos) -z $(arg z_pos) -param robot_description" />
 

--- a/turtlebot3_gazebo/launch/turtlebot3_stage_2.launch
+++ b/turtlebot3_gazebo/launch/turtlebot3_stage_2.launch
@@ -14,7 +14,7 @@
   </include>  
 
 
-  <param name="robot_description" command="$(find xacro)/xacro.py $(find turtlebot3_description)/urdf/turtlebot3_$(arg model).urdf.xacro" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder $(find turtlebot3_description)/urdf/turtlebot3_$(arg model).urdf.xacro" />
 
   <node name="spawn_urdf" pkg="gazebo_ros" type="spawn_model" args="-urdf -model turtlebot3_burger -x $(arg x_pos) -y $(arg y_pos) -z $(arg z_pos) -param robot_description" />
 </launch>

--- a/turtlebot3_gazebo/launch/turtlebot3_stage_3.launch
+++ b/turtlebot3_gazebo/launch/turtlebot3_stage_3.launch
@@ -13,7 +13,7 @@
     <arg name="debug" value="false"/>
   </include>  
 
-  <param name="robot_description" command="$(find xacro)/xacro.py $(find turtlebot3_description)/urdf/turtlebot3_$(arg model).urdf.xacro" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder $(find turtlebot3_description)/urdf/turtlebot3_$(arg model).urdf.xacro" />
 
   <node name="spawn_urdf" pkg="gazebo_ros" type="spawn_model" args="-urdf -model turtlebot3_burger -x $(arg x_pos) -y $(arg y_pos) -z $(arg z_pos) -param robot_description" />
 

--- a/turtlebot3_gazebo/launch/turtlebot3_stage_4.launch
+++ b/turtlebot3_gazebo/launch/turtlebot3_stage_4.launch
@@ -14,7 +14,7 @@
   </include>  
 
 
-  <param name="robot_description" command="$(find xacro)/xacro.py $(find turtlebot3_description)/urdf/turtlebot3_$(arg model).urdf.xacro" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder $(find turtlebot3_description)/urdf/turtlebot3_$(arg model).urdf.xacro" />
 
   <node name="spawn_urdf" pkg="gazebo_ros" type="spawn_model" args="-urdf -model turtlebot3_burger -x $(arg x_pos) -y $(arg y_pos) -z $(arg z_pos) -param robot_description" />
 


### PR DESCRIPTION
Replaces  `xacro.py` with `xacro --inorder`, as done here https://github.com/ROBOTIS-GIT/turtlebot3_simulations/commit/93c7de9915e35fe59db95d0d7ed39195aabf7632 for the other launch files.
It no longer works under ROS Noetic.