### PR TITLE
separated world and robot models

### DIFF
--- a/turtlebot3_gazebo/launch/empty_world.launch.py
+++ b/turtlebot3_gazebo/launch/empty_world.launch.py
@@ -14,48 +14,66 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Authors: Darby Lim
+# Authors: Joep Tool
 
 import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import ExecuteProcess
 from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 
-TURTLEBOT3_MODEL = os.environ['TURTLEBOT3_MODEL']
-
-
 def generate_launch_description():
-    use_sim_time = LaunchConfiguration('use_sim_time', default='True')
-    world_file_name = 'empty_worlds/' + TURTLEBOT3_MODEL + '.model'
-    world = os.path.join(get_package_share_directory('turtlebot3_gazebo'),
-                         'worlds', world_file_name)
-    launch_file_dir = os.path.join(get_package_share_directory('turtlebot3_gazebo'), 'launch')
-    pkg_gazebo_ros = get_package_share_directory('gazebo_ros')
+	launch_file_dir = os.path.join(get_package_share_directory('turtlebot3_gazebo'), 'launch')
+	pkg_gazebo_ros = get_package_share_directory('gazebo_ros')
+	
+	use_sim_time = LaunchConfiguration('use_sim_time', default='true')
+	x_pose = LaunchConfiguration('x_pose', default='0.0')
+	y_pose = LaunchConfiguration('y_pose', default='0.0')
 
-    return LaunchDescription([
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource(
-                os.path.join(pkg_gazebo_ros, 'launch', 'gzserver.launch.py')
-            ),
-            launch_arguments={'world': world}.items(),
-        ),
+	world = os.path.join(
+		get_package_share_directory('turtlebot3_gazebo'),
+		'worlds',
+		'empty_world.world'
+	)
 
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource(
-                os.path.join(pkg_gazebo_ros, 'launch', 'gzclient.launch.py')
-            ),
-        ),
+	gzserver_cmd = IncludeLaunchDescription(
+		PythonLaunchDescriptionSource(
+			os.path.join(pkg_gazebo_ros, 'launch', 'gzserver.launch.py')
+		),
+		launch_arguments={'world': world}.items()
+	)
 
-        ExecuteProcess(
-            cmd=['ros2', 'param', 'set', '/gazebo', 'use_sim_time', use_sim_time],
-            output='screen'),
+	gzclient_cmd = IncludeLaunchDescription(
+		PythonLaunchDescriptionSource(
+			os.path.join(pkg_gazebo_ros, 'launch', 'gzclient.launch.py')
+		)
+	)
 
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource([launch_file_dir, '/robot_state_publisher.launch.py']),
-            launch_arguments={'use_sim_time': use_sim_time}.items(),
-        ),
-    ])
+	robot_state_publisher_cmd = IncludeLaunchDescription(
+		PythonLaunchDescriptionSource(
+			os.path.join(launch_file_dir, 'robot_state_publisher.launch.py')
+		),
+		launch_arguments={'use_sim_time': use_sim_time}.items()
+	)
+
+	spawn_turtlebot_cmd = IncludeLaunchDescription(
+		PythonLaunchDescriptionSource(
+			os.path.join(launch_file_dir, 'spawn_turtlebot3.launch.py')
+		),
+		launch_arguments={
+			'x_pose': x_pose,
+			'y_pose': y_pose
+		}.items()
+	)
+
+	ld = LaunchDescription()
+
+	# Add the commands to the launch description
+	ld.add_action(gzserver_cmd)
+	ld.add_action(gzclient_cmd)
+	ld.add_action(robot_state_publisher_cmd)
+	ld.add_action(spawn_turtlebot_cmd)
+
+	return ld

--- a/turtlebot3_gazebo/launch/robot_state_publisher.launch.py
+++ b/turtlebot3_gazebo/launch/robot_state_publisher.launch.py
@@ -26,29 +26,36 @@ from launch_ros.actions import Node
 
 
 def generate_launch_description():
-    TURTLEBOT3_MODEL = os.environ['TURTLEBOT3_MODEL']
+	TURTLEBOT3_MODEL = os.environ['TURTLEBOT3_MODEL']
 
-    use_sim_time = LaunchConfiguration('use_sim_time', default='false')
-    urdf_file_name = 'turtlebot3_' + TURTLEBOT3_MODEL + '.urdf'
+	use_sim_time = LaunchConfiguration('use_sim_time', default='false')
+	urdf_file_name = 'turtlebot3_' + TURTLEBOT3_MODEL + '.urdf'
 
-    print('urdf_file_name : {}'.format(urdf_file_name))
+	print('urdf_file_name : {}'.format(urdf_file_name))
 
-    urdf = os.path.join(
-        get_package_share_directory('turtlebot3_description'),
-        'urdf',
-        urdf_file_name)
+	urdf_path = os.path.join(
+		get_package_share_directory('turtlebot3_description'),
+		'urdf',
+		urdf_file_name)
 
-    return LaunchDescription([
-        DeclareLaunchArgument(
-            'use_sim_time',
-            default_value='false',
-            description='Use simulation (Gazebo) clock if true'),
+	with open(urdf_path, 'r') as infp:
+		robot_desc = infp.read()
+			
 
-        Node(
-            package='robot_state_publisher',
-            executable='robot_state_publisher',
-            name='robot_state_publisher',
-            output='screen',
-            parameters=[{'use_sim_time': use_sim_time}],
-            arguments=[urdf]),
-    ])
+	return LaunchDescription([
+		DeclareLaunchArgument(
+			'use_sim_time',
+			default_value='false',
+			description='Use simulation (Gazebo) clock if true'),
+
+		Node(
+			package='robot_state_publisher',
+			executable='robot_state_publisher',
+			name='robot_state_publisher',
+			output='screen',
+			parameters=[{
+				'use_sim_time': use_sim_time,
+				'robot_description': robot_desc
+			}],
+		),
+	])

--- a/turtlebot3_gazebo/launch/spawn_turtlebot3.launch.py
+++ b/turtlebot3_gazebo/launch/spawn_turtlebot3.launch.py
@@ -1,0 +1,69 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from launch import LaunchDescription
+from launch.substitutions import LaunchConfiguration
+from launch.actions import DeclareLaunchArgument
+from launch_ros.actions import Node
+from ament_index_python.packages import get_package_share_directory
+
+def generate_launch_description():
+	# Get the urdf file
+	TURTLEBOT3_MODEL = os.environ['TURTLEBOT3_MODEL']
+	model_folder = 'turtlebot3_' + TURTLEBOT3_MODEL
+	urdf_path = os.path.join(
+		get_package_share_directory('turtlebot3_gazebo'), 
+		'models',
+		model_folder,
+		'model.sdf'
+	)
+
+	# Launch configuration variables specific to simulation
+	x_pose = LaunchConfiguration('x_pose', default='0.0')
+	y_pose = LaunchConfiguration('y_pose', default='0.0')
+
+	# Declare the launch arguments
+	declare_x_position_cmd = DeclareLaunchArgument(
+		'x_pose', default_value='0.0',
+		description='Specify namespace of the robot')
+
+	declare_y_position_cmd = DeclareLaunchArgument(
+		'y_pose', default_value='0.0',
+		description='Specify namespace of the robot')
+
+	start_gazebo_ros_spawner_cmd = 	Node(
+		package='gazebo_ros', 
+		executable='spawn_entity.py',
+		arguments=[
+			'-entity', TURTLEBOT3_MODEL,
+			'-file', urdf_path,
+			'-x', x_pose,
+			'-y', y_pose,
+			'-z', '0.01'
+		],
+		output='screen',
+	)
+
+	ld = LaunchDescription()
+
+	# Declare the launch options
+	# ld.add_action(declare_x_position_cmd)
+	# ld.add_action(declare_y_position_cmd)
+
+	# Add any conditioned actions
+	ld.add_action(start_gazebo_ros_spawner_cmd)
+
+	return ld

--- a/turtlebot3_gazebo/launch/turtlebot3_autorace.launch.py
+++ b/turtlebot3_gazebo/launch/turtlebot3_autorace.launch.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Authors: Ryan Shim
+# Authors: Joep Tool
 
 import os
 
@@ -24,33 +24,56 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 
-TURTLEBOT3_MODEL = os.environ['TURTLEBOT3_MODEL']
-
-
 def generate_launch_description():
-    use_sim_time = LaunchConfiguration('use_sim_time', default='true')
-    world_file_name = 'turtlebot3_autoraces/' + TURTLEBOT3_MODEL + '.model'
-    world = os.path.join(get_package_share_directory('turtlebot3_gazebo'),
-                         'worlds', world_file_name)
-    launch_file_dir = os.path.join(get_package_share_directory('turtlebot3_gazebo'), 'launch')
-    pkg_gazebo_ros = get_package_share_directory('gazebo_ros')
+	launch_file_dir = os.path.join(get_package_share_directory('turtlebot3_gazebo'), 'launch')
+	pkg_gazebo_ros = get_package_share_directory('gazebo_ros')
+	
+	use_sim_time = LaunchConfiguration('use_sim_time', default='true')
+	x_pose = LaunchConfiguration('x_pose', default='0.1')
+	y_pose = LaunchConfiguration('y_pose', default='-1.78')
 
-    return LaunchDescription([
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource(
-                os.path.join(pkg_gazebo_ros, 'launch', 'gzserver.launch.py')
-            ),
-            launch_arguments={'world': world}.items(),
-        ),
+	world = os.path.join(
+		get_package_share_directory('turtlebot3_gazebo'),
+		'worlds',
+		'turtlebot3_autorace.world'
+	)
 
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource(
-                os.path.join(pkg_gazebo_ros, 'launch', 'gzclient.launch.py')
-            ),
-        ),
+	gzserver_cmd = IncludeLaunchDescription(
+		PythonLaunchDescriptionSource(
+			os.path.join(pkg_gazebo_ros, 'launch', 'gzserver.launch.py')
+		),
+		launch_arguments={'world': world}.items()
+	)
 
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource([launch_file_dir, '/robot_state_publisher.launch.py']),
-            launch_arguments={'use_sim_time': use_sim_time}.items(),
-        ),
-    ])
+	gzclient_cmd = IncludeLaunchDescription(
+		PythonLaunchDescriptionSource(
+			os.path.join(pkg_gazebo_ros, 'launch', 'gzclient.launch.py')
+		)
+	)
+
+	robot_state_publisher_cmd = IncludeLaunchDescription(
+		PythonLaunchDescriptionSource(
+			os.path.join(launch_file_dir, 'robot_state_publisher.launch.py')
+		),
+		launch_arguments={'use_sim_time': use_sim_time}.items()
+	)
+
+	spawn_turtlebot_cmd = IncludeLaunchDescription(
+		PythonLaunchDescriptionSource(
+			os.path.join(launch_file_dir, 'spawn_turtlebot3.launch.py')
+		),
+		launch_arguments={
+			'x_pose': x_pose,
+			'y_pose': y_pose
+		}.items()
+	)
+
+	ld = LaunchDescription()
+
+	# Add the commands to the launch description
+	ld.add_action(gzserver_cmd)
+	ld.add_action(gzclient_cmd)
+	ld.add_action(robot_state_publisher_cmd)
+	ld.add_action(spawn_turtlebot_cmd)
+
+	return ld

--- a/turtlebot3_gazebo/launch/turtlebot3_dqn_stage1.launch.py
+++ b/turtlebot3_gazebo/launch/turtlebot3_dqn_stage1.launch.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Authors: Ryan Shim
+# Authors: Joep Tool
 
 import os
 
@@ -24,33 +24,56 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 
-TURTLEBOT3_MODEL = os.environ['TURTLEBOT3_MODEL']
-
-
 def generate_launch_description():
-    use_sim_time = LaunchConfiguration('use_sim_time', default='true')
-    world_file_name = 'turtlebot3_dqn_stage1/' + TURTLEBOT3_MODEL + '.model'
-    world = os.path.join(get_package_share_directory('turtlebot3_gazebo'),
-                         'worlds', world_file_name)
-    launch_file_dir = os.path.join(get_package_share_directory('turtlebot3_gazebo'), 'launch')
-    pkg_gazebo_ros = get_package_share_directory('gazebo_ros')
+	launch_file_dir = os.path.join(get_package_share_directory('turtlebot3_gazebo'), 'launch')
+	pkg_gazebo_ros = get_package_share_directory('gazebo_ros')
+	
+	use_sim_time = LaunchConfiguration('use_sim_time', default='true')
+	x_pose = LaunchConfiguration('x_pose', default='0.0')
+	y_pose = LaunchConfiguration('y_pose', default='0.0')
 
-    return LaunchDescription([
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource(
-                os.path.join(pkg_gazebo_ros, 'launch', 'gzserver.launch.py')
-            ),
-            launch_arguments={'world': world}.items(),
-        ),
+	world = os.path.join(
+		get_package_share_directory('turtlebot3_gazebo'),
+		'worlds',
+		'turtlebot3_dqn_stage1.world'
+	)
 
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource(
-                os.path.join(pkg_gazebo_ros, 'launch', 'gzclient.launch.py')
-            ),
-        ),
+	gzserver_cmd = IncludeLaunchDescription(
+		PythonLaunchDescriptionSource(
+			os.path.join(pkg_gazebo_ros, 'launch', 'gzserver.launch.py')
+		),
+		launch_arguments={'world': world}.items()
+	)
 
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource([launch_file_dir, '/robot_state_publisher.launch.py']),
-            launch_arguments={'use_sim_time': use_sim_time}.items(),
-        ),
-    ])
+	gzclient_cmd = IncludeLaunchDescription(
+		PythonLaunchDescriptionSource(
+			os.path.join(pkg_gazebo_ros, 'launch', 'gzclient.launch.py')
+		)
+	)
+
+	robot_state_publisher_cmd = IncludeLaunchDescription(
+		PythonLaunchDescriptionSource(
+			os.path.join(launch_file_dir, 'robot_state_publisher.launch.py')
+		),
+		launch_arguments={'use_sim_time': use_sim_time}.items()
+	)
+
+	spawn_turtlebot_cmd = IncludeLaunchDescription(
+		PythonLaunchDescriptionSource(
+			os.path.join(launch_file_dir, 'spawn_turtlebot3.launch.py')
+		),
+		launch_arguments={
+			'x_pose': x_pose,
+			'y_pose': y_pose
+		}.items()
+	)
+
+	ld = LaunchDescription()
+
+	# Add the commands to the launch description
+	ld.add_action(gzserver_cmd)
+	ld.add_action(gzclient_cmd)
+	ld.add_action(robot_state_publisher_cmd)
+	ld.add_action(spawn_turtlebot_cmd)
+
+	return ld

--- a/turtlebot3_gazebo/launch/turtlebot3_dqn_stage2.launch.py
+++ b/turtlebot3_gazebo/launch/turtlebot3_dqn_stage2.launch.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Authors: Ryan Shim
+# Authors: Joep Tool
 
 import os
 
@@ -24,33 +24,56 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 
-TURTLEBOT3_MODEL = os.environ['TURTLEBOT3_MODEL']
-
-
 def generate_launch_description():
-    use_sim_time = LaunchConfiguration('use_sim_time', default='true')
-    world_file_name = 'turtlebot3_dqn_stage2/' + TURTLEBOT3_MODEL + '.model'
-    world = os.path.join(get_package_share_directory('turtlebot3_gazebo'),
-                         'worlds', world_file_name)
-    launch_file_dir = os.path.join(get_package_share_directory('turtlebot3_gazebo'), 'launch')
-    pkg_gazebo_ros = get_package_share_directory('gazebo_ros')
+	launch_file_dir = os.path.join(get_package_share_directory('turtlebot3_gazebo'), 'launch')
+	pkg_gazebo_ros = get_package_share_directory('gazebo_ros')
+	
+	use_sim_time = LaunchConfiguration('use_sim_time', default='true')
+	x_pose = LaunchConfiguration('x_pose', default='0.0')
+	y_pose = LaunchConfiguration('y_pose', default='0.0')
 
-    return LaunchDescription([
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource(
-                os.path.join(pkg_gazebo_ros, 'launch', 'gzserver.launch.py')
-            ),
-            launch_arguments={'world': world}.items(),
-        ),
+	world = os.path.join(
+		get_package_share_directory('turtlebot3_gazebo'),
+		'worlds',
+		'turtlebot3_dqn_stage2.world'
+	)
 
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource(
-                os.path.join(pkg_gazebo_ros, 'launch', 'gzclient.launch.py')
-            ),
-        ),
+	gzserver_cmd = IncludeLaunchDescription(
+		PythonLaunchDescriptionSource(
+			os.path.join(pkg_gazebo_ros, 'launch', 'gzserver.launch.py')
+		),
+		launch_arguments={'world': world}.items()
+	)
 
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource([launch_file_dir, '/robot_state_publisher.launch.py']),
-            launch_arguments={'use_sim_time': use_sim_time}.items(),
-        ),
-    ])
+	gzclient_cmd = IncludeLaunchDescription(
+		PythonLaunchDescriptionSource(
+			os.path.join(pkg_gazebo_ros, 'launch', 'gzclient.launch.py')
+		)
+	)
+
+	robot_state_publisher_cmd = IncludeLaunchDescription(
+		PythonLaunchDescriptionSource(
+			os.path.join(launch_file_dir, 'robot_state_publisher.launch.py')
+		),
+		launch_arguments={'use_sim_time': use_sim_time}.items()
+	)
+
+	spawn_turtlebot_cmd = IncludeLaunchDescription(
+		PythonLaunchDescriptionSource(
+			os.path.join(launch_file_dir, 'spawn_turtlebot3.launch.py')
+		),
+		launch_arguments={
+			'x_pose': x_pose,
+			'y_pose': y_pose
+		}.items()
+	)
+
+	ld = LaunchDescription()
+
+	# Add the commands to the launch description
+	ld.add_action(gzserver_cmd)
+	ld.add_action(gzclient_cmd)
+	ld.add_action(robot_state_publisher_cmd)
+	ld.add_action(spawn_turtlebot_cmd)
+
+	return ld

--- a/turtlebot3_gazebo/launch/turtlebot3_dqn_stage3.launch.py
+++ b/turtlebot3_gazebo/launch/turtlebot3_dqn_stage3.launch.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Authors: Ryan Shim
+# Authors: Joep Tool
 
 import os
 
@@ -24,33 +24,56 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 
-TURTLEBOT3_MODEL = os.environ['TURTLEBOT3_MODEL']
-
-
 def generate_launch_description():
-    use_sim_time = LaunchConfiguration('use_sim_time', default='true')
-    world_file_name = 'turtlebot3_dqn_stage3/' + TURTLEBOT3_MODEL + '.model'
-    world = os.path.join(get_package_share_directory('turtlebot3_gazebo'),
-                         'worlds', world_file_name)
-    launch_file_dir = os.path.join(get_package_share_directory('turtlebot3_gazebo'), 'launch')
-    pkg_gazebo_ros = get_package_share_directory('gazebo_ros')
+	launch_file_dir = os.path.join(get_package_share_directory('turtlebot3_gazebo'), 'launch')
+	pkg_gazebo_ros = get_package_share_directory('gazebo_ros')
+	
+	use_sim_time = LaunchConfiguration('use_sim_time', default='true')
+	x_pose = LaunchConfiguration('x_pose', default='0.0')
+	y_pose = LaunchConfiguration('y_pose', default='0.0')
 
-    return LaunchDescription([
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource(
-                os.path.join(pkg_gazebo_ros, 'launch', 'gzserver.launch.py')
-            ),
-            launch_arguments={'world': world}.items(),
-        ),
+	world = os.path.join(
+		get_package_share_directory('turtlebot3_gazebo'),
+		'worlds',
+		'turtlebot3_dqn_stage3.world'
+	)
 
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource(
-                os.path.join(pkg_gazebo_ros, 'launch', 'gzclient.launch.py')
-            ),
-        ),
+	gzserver_cmd = IncludeLaunchDescription(
+		PythonLaunchDescriptionSource(
+			os.path.join(pkg_gazebo_ros, 'launch', 'gzserver.launch.py')
+		),
+		launch_arguments={'world': world}.items()
+	)
 
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource([launch_file_dir, '/robot_state_publisher.launch.py']),
-            launch_arguments={'use_sim_time': use_sim_time}.items(),
-        ),
-    ])
+	gzclient_cmd = IncludeLaunchDescription(
+		PythonLaunchDescriptionSource(
+			os.path.join(pkg_gazebo_ros, 'launch', 'gzclient.launch.py')
+		)
+	)
+
+	robot_state_publisher_cmd = IncludeLaunchDescription(
+		PythonLaunchDescriptionSource(
+			os.path.join(launch_file_dir, 'robot_state_publisher.launch.py')
+		),
+		launch_arguments={'use_sim_time': use_sim_time}.items()
+	)
+
+	spawn_turtlebot_cmd = IncludeLaunchDescription(
+		PythonLaunchDescriptionSource(
+			os.path.join(launch_file_dir, 'spawn_turtlebot3.launch.py')
+		),
+		launch_arguments={
+			'x_pose': x_pose,
+			'y_pose': y_pose
+		}.items()
+	)
+
+	ld = LaunchDescription()
+
+	# Add the commands to the launch description
+	ld.add_action(gzserver_cmd)
+	ld.add_action(gzclient_cmd)
+	ld.add_action(robot_state_publisher_cmd)
+	ld.add_action(spawn_turtlebot_cmd)
+
+	return ld

--- a/turtlebot3_gazebo/launch/turtlebot3_dqn_stage4.launch.py
+++ b/turtlebot3_gazebo/launch/turtlebot3_dqn_stage4.launch.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Authors: Ryan Shim
+# Authors: Joep Tool
 
 import os
 
@@ -24,33 +24,56 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 
-TURTLEBOT3_MODEL = os.environ['TURTLEBOT3_MODEL']
-
-
 def generate_launch_description():
-    use_sim_time = LaunchConfiguration('use_sim_time', default='true')
-    world_file_name = 'turtlebot3_dqn_stage4/' + TURTLEBOT3_MODEL + '.model'
-    world = os.path.join(get_package_share_directory('turtlebot3_gazebo'),
-                         'worlds', world_file_name)
-    launch_file_dir = os.path.join(get_package_share_directory('turtlebot3_gazebo'), 'launch')
-    pkg_gazebo_ros = get_package_share_directory('gazebo_ros')
+	launch_file_dir = os.path.join(get_package_share_directory('turtlebot3_gazebo'), 'launch')
+	pkg_gazebo_ros = get_package_share_directory('gazebo_ros')
+	
+	use_sim_time = LaunchConfiguration('use_sim_time', default='true')
+	x_pose = LaunchConfiguration('x_pose', default='0.0')
+	y_pose = LaunchConfiguration('y_pose', default='0.0')
 
-    return LaunchDescription([
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource(
-                os.path.join(pkg_gazebo_ros, 'launch', 'gzserver.launch.py')
-            ),
-            launch_arguments={'world': world}.items(),
-        ),
+	world = os.path.join(
+		get_package_share_directory('turtlebot3_gazebo'),
+		'worlds',
+		'turtlebot3_dqn_stage4.world'
+	)
 
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource(
-                os.path.join(pkg_gazebo_ros, 'launch', 'gzclient.launch.py')
-            ),
-        ),
+	gzserver_cmd = IncludeLaunchDescription(
+		PythonLaunchDescriptionSource(
+			os.path.join(pkg_gazebo_ros, 'launch', 'gzserver.launch.py')
+		),
+		launch_arguments={'world': world}.items()
+	)
 
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource([launch_file_dir, '/robot_state_publisher.launch.py']),
-            launch_arguments={'use_sim_time': use_sim_time}.items(),
-        ),
-    ])
+	gzclient_cmd = IncludeLaunchDescription(
+		PythonLaunchDescriptionSource(
+			os.path.join(pkg_gazebo_ros, 'launch', 'gzclient.launch.py')
+		)
+	)
+
+	robot_state_publisher_cmd = IncludeLaunchDescription(
+		PythonLaunchDescriptionSource(
+			os.path.join(launch_file_dir, 'robot_state_publisher.launch.py')
+		),
+		launch_arguments={'use_sim_time': use_sim_time}.items()
+	)
+
+	spawn_turtlebot_cmd = IncludeLaunchDescription(
+		PythonLaunchDescriptionSource(
+			os.path.join(launch_file_dir, 'spawn_turtlebot3.launch.py')
+		),
+		launch_arguments={
+			'x_pose': x_pose,
+			'y_pose': y_pose
+		}.items()
+	)
+
+	ld = LaunchDescription()
+
+	# Add the commands to the launch description
+	ld.add_action(gzserver_cmd)
+	ld.add_action(gzclient_cmd)
+	ld.add_action(robot_state_publisher_cmd)
+	ld.add_action(spawn_turtlebot_cmd)
+
+	return ld

--- a/turtlebot3_gazebo/launch/turtlebot3_house.launch.py
+++ b/turtlebot3_gazebo/launch/turtlebot3_house.launch.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Authors: Darby Lim, Ryan Shim
+# Authors: Joep Tool
 
 import os
 
@@ -24,33 +24,56 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 
-TURTLEBOT3_MODEL = os.environ['TURTLEBOT3_MODEL']
-
-
 def generate_launch_description():
-    use_sim_time = LaunchConfiguration('use_sim_time', default='true')
-    world_file_name = 'turtlebot3_houses/' + TURTLEBOT3_MODEL + '.model'
-    world = os.path.join(get_package_share_directory('turtlebot3_gazebo'),
-                         'worlds', world_file_name)
-    launch_file_dir = os.path.join(get_package_share_directory('turtlebot3_gazebo'), 'launch')
-    pkg_gazebo_ros = get_package_share_directory('gazebo_ros')
+	launch_file_dir = os.path.join(get_package_share_directory('turtlebot3_gazebo'), 'launch')
+	pkg_gazebo_ros = get_package_share_directory('gazebo_ros')
+	
+	use_sim_time = LaunchConfiguration('use_sim_time', default='true')
+	x_pose = LaunchConfiguration('x_pose', default='-2.0')
+	y_pose = LaunchConfiguration('y_pose', default='-0.5')
 
-    return LaunchDescription([
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource(
-                os.path.join(pkg_gazebo_ros, 'launch', 'gzserver.launch.py')
-            ),
-            launch_arguments={'world': world}.items(),
-        ),
+	world = os.path.join(
+		get_package_share_directory('turtlebot3_gazebo'),
+		'worlds',
+		'turtlebot3_house.world'
+	)
 
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource(
-                os.path.join(pkg_gazebo_ros, 'launch', 'gzclient.launch.py')
-            ),
-        ),
+	gzserver_cmd = IncludeLaunchDescription(
+		PythonLaunchDescriptionSource(
+			os.path.join(pkg_gazebo_ros, 'launch', 'gzserver.launch.py')
+		),
+		launch_arguments={'world': world}.items()
+	)
 
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource([launch_file_dir, '/robot_state_publisher.launch.py']),
-            launch_arguments={'use_sim_time': use_sim_time}.items(),
-        ),
-    ])
+	gzclient_cmd = IncludeLaunchDescription(
+		PythonLaunchDescriptionSource(
+			os.path.join(pkg_gazebo_ros, 'launch', 'gzclient.launch.py')
+		)
+	)
+
+	robot_state_publisher_cmd = IncludeLaunchDescription(
+		PythonLaunchDescriptionSource(
+			os.path.join(launch_file_dir, 'robot_state_publisher.launch.py')
+		),
+		launch_arguments={'use_sim_time': use_sim_time}.items()
+	)
+
+	spawn_turtlebot_cmd = IncludeLaunchDescription(
+		PythonLaunchDescriptionSource(
+			os.path.join(launch_file_dir, 'spawn_turtlebot3.launch.py')
+		),
+		launch_arguments={
+			'x_pose': x_pose,
+			'y_pose': y_pose
+		}.items()
+	)
+
+	ld = LaunchDescription()
+
+	# Add the commands to the launch description
+	ld.add_action(gzserver_cmd)
+	ld.add_action(gzclient_cmd)
+	ld.add_action(robot_state_publisher_cmd)
+	ld.add_action(spawn_turtlebot_cmd)
+
+	return ld

--- a/turtlebot3_gazebo/launch/turtlebot3_world.launch.py
+++ b/turtlebot3_gazebo/launch/turtlebot3_world.launch.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Authors: Darby Lim
+# Authors: Joep Tool
 
 import os
 
@@ -24,33 +24,56 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 
-TURTLEBOT3_MODEL = os.environ['TURTLEBOT3_MODEL']
-
-
 def generate_launch_description():
-    use_sim_time = LaunchConfiguration('use_sim_time', default='true')
-    world_file_name = 'turtlebot3_worlds/' + TURTLEBOT3_MODEL + '.model'
-    world = os.path.join(get_package_share_directory('turtlebot3_gazebo'),
-                         'worlds', world_file_name)
-    launch_file_dir = os.path.join(get_package_share_directory('turtlebot3_gazebo'), 'launch')
-    pkg_gazebo_ros = get_package_share_directory('gazebo_ros')
+	launch_file_dir = os.path.join(get_package_share_directory('turtlebot3_gazebo'), 'launch')
+	pkg_gazebo_ros = get_package_share_directory('gazebo_ros')
+	
+	use_sim_time = LaunchConfiguration('use_sim_time', default='true')
+	x_pose = LaunchConfiguration('x_pose', default='-2.0')
+	y_pose = LaunchConfiguration('y_pose', default='-0.5')
 
-    return LaunchDescription([
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource(
-                os.path.join(pkg_gazebo_ros, 'launch', 'gzserver.launch.py')
-            ),
-            launch_arguments={'world': world}.items(),
-        ),
+	world = os.path.join(
+		get_package_share_directory('turtlebot3_gazebo'),
+		'worlds',
+		'turtlebot3_world.world'
+	)
 
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource(
-                os.path.join(pkg_gazebo_ros, 'launch', 'gzclient.launch.py')
-            ),
-        ),
+	gzserver_cmd = IncludeLaunchDescription(
+		PythonLaunchDescriptionSource(
+			os.path.join(pkg_gazebo_ros, 'launch', 'gzserver.launch.py')
+		),
+		launch_arguments={'world': world}.items()
+	)
 
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource([launch_file_dir, '/robot_state_publisher.launch.py']),
-            launch_arguments={'use_sim_time': use_sim_time}.items(),
-        ),
-    ])
+	gzclient_cmd = IncludeLaunchDescription(
+		PythonLaunchDescriptionSource(
+			os.path.join(pkg_gazebo_ros, 'launch', 'gzclient.launch.py')
+		)
+	)
+
+	robot_state_publisher_cmd = IncludeLaunchDescription(
+		PythonLaunchDescriptionSource(
+			os.path.join(launch_file_dir, 'robot_state_publisher.launch.py')
+		),
+		launch_arguments={'use_sim_time': use_sim_time}.items()
+	)
+
+	spawn_turtlebot_cmd = IncludeLaunchDescription(
+		PythonLaunchDescriptionSource(
+			os.path.join(launch_file_dir, 'spawn_turtlebot3.launch.py')
+		),
+		launch_arguments={
+			'x_pose': x_pose,
+			'y_pose': y_pose
+		}.items()
+	)
+
+	ld = LaunchDescription()
+
+	# Add the commands to the launch description
+	ld.add_action(gzserver_cmd)
+	ld.add_action(gzclient_cmd)
+	ld.add_action(robot_state_publisher_cmd)
+	ld.add_action(spawn_turtlebot_cmd)
+
+	return ld

--- a/turtlebot3_gazebo/worlds/empty_world.world
+++ b/turtlebot3_gazebo/worlds/empty_world.world
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <world name="default">
+
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+
+    <include>
+      <uri>model://sun</uri>
+    </include>
+
+    <scene>
+      <shadows>false</shadows>
+    </scene>
+
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose frame=''>0.319654 -0.235002 9.29441 0 1.5138 0.009599</pose>
+        <view_controller>orbit</view_controller>
+        <projection_type>perspective</projection_type>
+      </camera>
+    </gui>
+
+    <physics type="ode">
+      <real_time_update_rate>1000.0</real_time_update_rate>
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <ode>
+        <solver>
+          <type>quick</type>
+          <iters>150</iters>
+          <precon_iters>0</precon_iters>
+          <sor>1.400000</sor>
+          <use_dynamic_moi_rescaling>1</use_dynamic_moi_rescaling>
+        </solver>
+        <constraints>
+          <cfm>0.00001</cfm>
+          <erp>0.2</erp>
+          <contact_max_correcting_vel>2000.000000</contact_max_correcting_vel>
+          <contact_surface_layer>0.01000</contact_surface_layer>
+        </constraints>
+      </ode>
+    </physics>
+
+  </world>
+</sdf>

--- a/turtlebot3_gazebo/worlds/turtlebot3_autorace.world
+++ b/turtlebot3_gazebo/worlds/turtlebot3_autorace.world
@@ -1,0 +1,83 @@
+<?xml version="1.0"?>
+<sdf version='1.6'>
+  <world name='default'>
+
+    <include>
+      <uri>model://sun</uri>
+    </include>
+
+    <scene>
+      <shadows>false</shadows>
+    </scene>
+
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose frame=''>2.7696 -1.93094 6.71513 0 1.1618 2.27182</pose>
+        <view_controller>orbit</view_controller>
+        <projection_type>perspective</projection_type>
+      </camera>
+    </gui>
+    
+    <physics type="ode">
+      <real_time_update_rate>1000.0</real_time_update_rate>
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <ode>
+        <solver>
+          <type>quick</type>
+          <iters>150</iters>
+          <precon_iters>0</precon_iters>
+          <sor>1.400000</sor>
+          <use_dynamic_moi_rescaling>1</use_dynamic_moi_rescaling>
+        </solver>
+        <constraints>
+          <cfm>0.00001</cfm>
+          <erp>0.2</erp>
+          <contact_max_correcting_vel>2000.000000</contact_max_correcting_vel>
+          <contact_surface_layer>0.01000</contact_surface_layer>
+        </constraints>
+      </ode>
+    </physics>
+
+    <include>
+      <uri>model://turtlebot3_autorace/course</uri>
+      <pose> 0 0 0 0 0 -1.54</pose>
+    </include>
+
+    <include>
+      <uri>model://turtlebot3_autorace/ground</uri>
+      <pose> 0 0 -0.1 0 0 0</pose>
+    </include>
+    
+    <include>
+      <uri>model://turtlebot3_autorace/lights</uri>
+      <pose> 0 0 0 0 0 0</pose>
+    </include>
+
+    <include>
+      <uri>model://turtlebot3_autorace/traffic_parking</uri>
+      <pose> 1.84 1.27 0.13 0 0 -0.356</pose>
+    </include>
+    
+    <include>
+      <uri>model://turtlebot3_autorace/traffic_tunnel</uri>
+      <pose> -1.544 -0.08 0.125 0 0 0</pose>
+    </include>
+   
+    <include>
+      <uri>model://turtlebot3_autorace/traffic_stop</uri>
+       <pose> -2.05 0.65 0.125 0 -0 0</pose>
+    </include>    
+
+    <include>
+      <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+      <uri>model://turtlebot3_autorace/tunnel_wall</uri>
+    </include>
+
+    <include>
+      <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose>
+      <uri>model://turtlebot3_autorace/tunnel_obstacles</uri>
+    </include>
+
+  </world>
+</sdf>

--- a/turtlebot3_gazebo/worlds/turtlebot3_dqn_stage1.world
+++ b/turtlebot3_gazebo/worlds/turtlebot3_dqn_stage1.world
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <world name="default">
+
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+
+    <include>
+      <uri>model://sun</uri>
+    </include>
+
+    <scene>
+      <shadows>false</shadows>
+    </scene>
+
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose frame=''>0.319654 -0.235002 9.29441 0 1.5138 0.009599</pose>
+        <view_controller>orbit</view_controller>
+        <projection_type>perspective</projection_type>
+      </camera>
+    </gui>
+
+    <physics type="ode">
+      <real_time_update_rate>1000.0</real_time_update_rate>
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <ode>
+        <solver>
+          <type>quick</type>
+          <iters>150</iters>
+          <precon_iters>0</precon_iters>
+          <sor>1.400000</sor>
+          <use_dynamic_moi_rescaling>1</use_dynamic_moi_rescaling>
+        </solver>
+        <constraints>
+          <cfm>0.00001</cfm>
+          <erp>0.2</erp>
+          <contact_max_correcting_vel>2000.000000</contact_max_correcting_vel>
+          <contact_surface_layer>0.01000</contact_surface_layer>
+        </constraints>
+      </ode>
+    </physics>
+    
+    <model name="turtlebot3_dqn_world">
+      <static>1</static>
+      <include>
+        <uri>model://turtlebot3_dqn_world</uri>
+      </include>
+    </model>
+
+  </world>
+</sdf>

--- a/turtlebot3_gazebo/worlds/turtlebot3_dqn_stage2.world
+++ b/turtlebot3_gazebo/worlds/turtlebot3_dqn_stage2.world
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <world name="default">
+
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+
+    <include>
+      <uri>model://sun</uri>
+    </include>
+
+    <scene>
+      <shadows>false</shadows>
+    </scene>
+
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose frame=''>0.319654 -0.235002 9.29441 0 1.5138 0.009599</pose>
+        <view_controller>orbit</view_controller>
+        <projection_type>perspective</projection_type>
+      </camera>
+    </gui>
+
+    <physics type="ode">
+      <real_time_update_rate>1000.0</real_time_update_rate>
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <ode>
+        <solver>
+          <type>quick</type>
+          <iters>150</iters>
+          <precon_iters>0</precon_iters>
+          <sor>1.400000</sor>
+          <use_dynamic_moi_rescaling>1</use_dynamic_moi_rescaling>
+        </solver>
+        <constraints>
+          <cfm>0.00001</cfm>
+          <erp>0.2</erp>
+          <contact_max_correcting_vel>2000.000000</contact_max_correcting_vel>
+          <contact_surface_layer>0.01000</contact_surface_layer>
+        </constraints>
+      </ode>
+    </physics>
+
+    <model name="turtlebot3_dqn_world">
+      <static>1</static>
+      <include>
+        <uri>model://turtlebot3_dqn_world</uri>
+      </include>
+    </model>
+
+    <include>
+      <uri>model://turtlebot3_dqn_world/obstacles</uri>
+    </include>
+
+  </world>
+</sdf>

--- a/turtlebot3_gazebo/worlds/turtlebot3_dqn_stage3.world
+++ b/turtlebot3_gazebo/worlds/turtlebot3_dqn_stage3.world
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <world name="default">
+
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+
+    <include>
+      <uri>model://sun</uri>
+    </include>
+
+    <scene>
+      <shadows>false</shadows>
+    </scene>
+
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose frame=''>0.319654 -0.235002 9.29441 0 1.5138 0.009599</pose>
+        <view_controller>orbit</view_controller>
+        <projection_type>perspective</projection_type>
+      </camera>
+    </gui>
+
+    <physics type="ode">
+      <real_time_update_rate>1000.0</real_time_update_rate>
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <ode>
+        <solver>
+          <type>quick</type>
+          <iters>150</iters>
+          <precon_iters>0</precon_iters>
+          <sor>1.400000</sor>
+          <use_dynamic_moi_rescaling>1</use_dynamic_moi_rescaling>
+        </solver>
+        <constraints>
+          <cfm>0.00001</cfm>
+          <erp>0.2</erp>
+          <contact_max_correcting_vel>2000.000000</contact_max_correcting_vel>
+          <contact_surface_layer>0.01000</contact_surface_layer>
+        </constraints>
+      </ode>
+    </physics>
+
+    <model name="turtlebot3_dqn_world">
+      <static>1</static>
+      <include>
+        <uri>model://turtlebot3_dqn_world</uri>
+      </include>
+    </model>
+
+    <model name="turtlebot3_dqn_obstacles">
+      <plugin name="obstacles" filename="libobstacles.so"/>
+      <allow_auto_disable>1</allow_auto_disable>
+      <include>
+        <uri>model://turtlebot3_dqn_world/obstacles</uri>
+      </include>
+    </model>
+
+  </world>
+</sdf>

--- a/turtlebot3_gazebo/worlds/turtlebot3_dqn_stage4.world
+++ b/turtlebot3_gazebo/worlds/turtlebot3_dqn_stage4.world
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <world name="default">
+
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+
+    <include>
+      <uri>model://sun</uri>
+    </include>
+
+    <scene>
+      <shadows>false</shadows>
+    </scene>
+
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose frame=''>0.319654 -0.235002 9.29441 0 1.5138 0.009599</pose>
+        <view_controller>orbit</view_controller>
+        <projection_type>perspective</projection_type>
+      </camera>
+    </gui>
+
+    <physics type="ode">
+      <real_time_update_rate>1000.0</real_time_update_rate>
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <ode>
+        <solver>
+          <type>quick</type>
+          <iters>150</iters>
+          <precon_iters>0</precon_iters>
+          <sor>1.400000</sor>
+          <use_dynamic_moi_rescaling>1</use_dynamic_moi_rescaling>
+        </solver>
+        <constraints>
+          <cfm>0.00001</cfm>
+          <erp>0.2</erp>
+          <contact_max_correcting_vel>2000.000000</contact_max_correcting_vel>
+          <contact_surface_layer>0.01000</contact_surface_layer>
+        </constraints>
+      </ode>
+    </physics>
+
+    <model name="turtlebot3_dqn_world">
+      <static>1</static>
+      <include>
+        <uri>model://turtlebot3_dqn_world</uri>
+      </include>
+    </model>
+
+    <include>
+      <pose>0 0 0 0 0 0</pose>
+      <uri>model://turtlebot3_dqn_world/inner_walls</uri>
+    </include>
+
+    <model name="turtlebot3_dqn_obstacle1">
+      <plugin name="obstacle1" filename="libobstacle1.so"/>
+      <include>
+        <pose>2 2 0 0 0 0</pose>
+        <uri>model://turtlebot3_dqn_world/obstacle1</uri>
+      </include>
+    </model>
+     
+    <model name="turtlebot3_dqn_obstacle2">
+      <plugin name="obstacle2" filename="libobstacle2.so"/>
+      <include>
+        <pose>-2 -2 0 0 0 0</pose>
+        <uri>model://turtlebot3_dqn_world/obstacle2</uri>
+      </include>
+    </model>
+
+  </world>
+</sdf>

--- a/turtlebot3_gazebo/worlds/turtlebot3_house.world
+++ b/turtlebot3_gazebo/worlds/turtlebot3_house.world
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <world name="default">
+
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+
+    <include>
+      <uri>model://sun</uri>
+    </include>
+
+    <scene>
+      <shadows>false</shadows>
+    </scene>
+
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose frame=''>0.319654 -0.235002 9.29441 0 1.5138 0.009599</pose>
+        <view_controller>orbit</view_controller>
+        <projection_type>perspective</projection_type>
+      </camera>
+    </gui>
+
+    <physics type="ode">
+      <real_time_update_rate>1000.0</real_time_update_rate>
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <ode>
+        <solver>
+          <type>quick</type>
+          <iters>150</iters>
+          <precon_iters>0</precon_iters>
+          <sor>1.400000</sor>
+          <use_dynamic_moi_rescaling>1</use_dynamic_moi_rescaling>
+        </solver>
+        <constraints>
+          <cfm>0.00001</cfm>
+          <erp>0.2</erp>
+          <contact_max_correcting_vel>2000.000000</contact_max_correcting_vel>
+          <contact_surface_layer>0.01000</contact_surface_layer>
+        </constraints>
+      </ode>
+    </physics>
+
+    <model name="turtlebot3_house">
+      <static>1</static>
+      <include>
+        <uri>model://turtlebot3_house</uri>
+      </include>
+    </model>
+
+  </world>
+</sdf>

--- a/turtlebot3_gazebo/worlds/turtlebot3_world.world
+++ b/turtlebot3_gazebo/worlds/turtlebot3_world.world
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <world name="default">
+
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+
+    <include>
+      <uri>model://sun</uri>
+    </include>
+
+    <scene>
+      <shadows>false</shadows>
+    </scene>
+
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose frame=''>0.319654 -0.235002 9.29441 0 1.5138 0.009599</pose>
+        <view_controller>orbit</view_controller>
+        <projection_type>perspective</projection_type>
+      </camera>
+    </gui>
+
+    <physics type="ode">
+      <real_time_update_rate>1000.0</real_time_update_rate>
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1</real_time_factor>
+      <ode>
+        <solver>
+          <type>quick</type>
+          <iters>150</iters>
+          <precon_iters>0</precon_iters>
+          <sor>1.400000</sor>
+          <use_dynamic_moi_rescaling>1</use_dynamic_moi_rescaling>
+        </solver>
+        <constraints>
+          <cfm>0.00001</cfm>
+          <erp>0.2</erp>
+          <contact_max_correcting_vel>2000.000000</contact_max_correcting_vel>
+          <contact_surface_layer>0.01000</contact_surface_layer>
+        </constraints>
+      </ode>
+    </physics>
+
+    <model name="turtlebot3_world">
+      <static>1</static>
+      <include>
+        <uri>model://turtlebot3_world</uri>
+      </include>
+    </model>
+
+  </world>
+</sdf>


### PR DESCRIPTION
As per #115 I removed the robot models from the worlds and instead added them using gazebo_ros spawner. 

For compatibility I thought it would be best not to remove any of the now redundant world folders.

I also did a quick update regarding the robot_state_publisher, as `arguments=[urdf])` gives a deprecated warning. Instead it the content of the urdf file should now be included in a parameter.