### PR TITLE
Update cmake_minimum_required version range to 3.0..3.20

### DIFF
--- a/turtlebot3_fake/CMakeLists.txt
+++ b/turtlebot3_fake/CMakeLists.txt
@@ -1,7 +1,7 @@
 ################################################################################
 # Set minimum required version of cmake, project name and compile options
 ################################################################################
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0...3.20)
 project(turtlebot3_fake)
 
 ################################################################################

--- a/turtlebot3_gazebo/CMakeLists.txt
+++ b/turtlebot3_gazebo/CMakeLists.txt
@@ -1,7 +1,7 @@
 ################################################################################
 # Set minimum required version of cmake, project name and compile options
 ################################################################################
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0...3.20)
 project(turtlebot3_gazebo)
 
 ## Compile as C++11, supported in ROS Kinetic and newer

--- a/turtlebot3_simulations/CMakeLists.txt
+++ b/turtlebot3_simulations/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0...3.20)
 project(turtlebot3_simulations)
 find_package(catkin REQUIRED)
 catkin_metapackage()


### PR DESCRIPTION
This commit updates cmake_minimum_required version range to 3.0..3.20 to fix build warnings when building on newer Ubuntu releases (e.g. Ubuntu-20.04).