### PR TITLE
add /camera/image source to rviz config

### DIFF
--- a/turtlebot3_gazebo/rviz/turtlebot3_gazebo_model.rviz
+++ b/turtlebot3_gazebo/rviz/turtlebot3_gazebo_model.rviz
@@ -172,6 +172,18 @@ Visualization Manager:
         TF: true
         Value: true
       Zoom Factor: 1
+    - Class: rviz/Image
+      Enabled: true
+      Image Topic: /camera/image
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Image
+      Normalize Range: true
+      Queue Size: 2
+      Transport Hint: raw
+      Unreliable: false
+      Value: true
     - Angle Tolerance: 0.10000000149011612
       Class: rviz/Odometry
       Covariance:


### PR DESCRIPTION
For me `/camera/rgb/image_raw` isn't working, but `/camera/image` as rviz/Image is.

if it can help, here is the corresponding changes to the rviz config.