### PR TITLE
Multi robot launch in gazebo and multi robots  control with namespace.

### DIFF
--- a/.github/workflows/ros-ci.yml
+++ b/.github/workflows/ros-ci.yml
@@ -1,15 +1,15 @@
-name: humble-devel
+name: humble
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 on:
   push:
-    branches: [ humble-devel ]
+    branches: [ main, humble ]
   pull_request:
-    branches: [ humble-devel ]
+    branches: [ main, humble ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  humble-devel:
+  humble:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ros-ci.yml
+++ b/.github/workflows/ros-ci.yml
@@ -1,39 +1,34 @@
-name: humble
+name: CI
 
-# Controls when the action will run. Triggers the workflow on push or pull request
+# Specifies the events that trigger the workflow
 on:
   push:
     branches: [ main, humble ]
   pull_request:
     branches: [ main, humble ]
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+# Defines a set of jobs to be run as part of the workflow
 jobs:
-  humble:
-    runs-on: ubuntu-latest
+  # The name of the job
+  ROS_CI:
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         ros_distribution:
-          #- foxy
-          # - galactic
           - humble
           # - rolling
         include:
-            # Foxy Fitzroy (June 2020 - May 2023)
-          # - docker_image: ubuntu:focal
-          #   ros_distribution: foxy
-          #   ros_version: 2
-          #   # Galactic Geochelone (May 2021)
-          # - docker_image: ubuntu:focal
-          #   ros_distribution: galactic
-          #   ros_version: 2
             # Humble Hawksbill (May 2027)
           - docker_image: ubuntu:jammy
             ros_distribution: humble
             ros_version: 2
-          #   # Rolling
-          # - docker_image: ubuntu:jammy
+          # ROS 2 Jazzy Jalisco
+          # - docker_image: ubuntu:noble
+          #   ros_distribution: jazzy
+          #   ros_version: 2
+          # ROS 2 Rolling Ridley
+          # - docker_image: ubuntu:noble
           #   ros_distribution: rolling
           #   ros_version: 2
     container:
@@ -41,18 +36,23 @@ jobs:
     steps:
       - name: Setup directories
         run: mkdir -p ros_ws/src
+
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ros_ws/src
+
       - name: Setup ROS environment
-        uses: ros-tooling/setup-ros@0.3.3
+        uses: ros-tooling/setup-ros@0.7
         with:
           required-ros-distributions: ${{ matrix.ros_distribution }}
       - name: Build and Test
-        uses: ros-tooling/action-ros-ci@0.2.5
+        uses: ros-tooling/action-ros-ci@0.3
         with:
-          package-name: turtlebot3_simulations
+
           target-ros2-distro: ${{ matrix.ros_distribution }}
-          vcs-repo-file-url: "https://raw.githubusercontent.com/ROBOTIS-GIT/turtlebot3_simulations/ros2-devel/turtlebot3_simulations_ci.repos"
-  
+          vcs-repo-file-url: "https://raw.githubusercontent.com/ROBOTIS-GIT/turtlebot3_simulations/main/turtlebot3_simulations_ci.repos"
+          package-name: |
+          turtlebot3_simulations
+          turtlebot3_gazebo
+          turtlebot3_fake_node

--- a/.github/workflows/ros-ci.yml
+++ b/.github/workflows/ros-ci.yml
@@ -1,3 +1,4 @@
+# The name of the workflow
 name: CI
 
 # Specifies the events that trigger the workflow
@@ -17,9 +18,10 @@ jobs:
       matrix:
         ros_distribution:
           - humble
+          # - jazzy
           # - rolling
         include:
-            # Humble Hawksbill (May 2027)
+          # ROS 2 Humble Hawksbill
           - docker_image: ubuntu:jammy
             ros_distribution: humble
             ros_version: 2
@@ -34,25 +36,25 @@ jobs:
     container:
       image: ${{ matrix.docker_image }}
     steps:
-      - name: Setup directories
+      - name: Setup workspace
         run: mkdir -p ros_ws/src
 
-      - name: checkout
+      - name: Checkout code
         uses: actions/checkout@v4
         with:
           path: ros_ws/src
 
       - name: Setup ROS environment
-        uses: ros-tooling/setup-ros@0.7
+        uses: ros-tooling/setup-ros@v0.7
         with:
           required-ros-distributions: ${{ matrix.ros_distribution }}
-      - name: Build and Test
-        uses: ros-tooling/action-ros-ci@0.3
-        with:
 
+      - name: Build and Test
+        uses: ros-tooling/action-ros-ci@v0.3
+        with:
           target-ros2-distro: ${{ matrix.ros_distribution }}
-          vcs-repo-file-url: "https://raw.githubusercontent.com/ROBOTIS-GIT/turtlebot3_simulations/main/turtlebot3_simulations_ci.repos"
+          vcs-repo-file-url: "https://raw.githubusercontent.com/ROBOTIS-GIT/turtlebot3/main/turtlebot3_ci.repos"
           package-name: |
-          turtlebot3_simulations
-          turtlebot3_gazebo
-          turtlebot3_fake_node
+            turtlebot3_fake_node
+            turtlebot3_gazebo
+            turtlebot3_simulations

--- a/.github/workflows/ros-ci.yml
+++ b/.github/workflows/ros-ci.yml
@@ -53,7 +53,7 @@ jobs:
         uses: ros-tooling/action-ros-ci@v0.3
         with:
           target-ros2-distro: ${{ matrix.ros_distribution }}
-          vcs-repo-file-url: "https://raw.githubusercontent.com/ROBOTIS-GIT/turtlebot3/main/turtlebot3_ci.repos"
+          vcs-repo-file-url: "https://raw.githubusercontent.com/ROBOTIS-GIT/turtlebot3_simulations/main/turtlebot3_simulations_ci.repos"
           package-name: |
             turtlebot3_fake_node
             turtlebot3_gazebo

--- a/.github/workflows/ros-lint.yml
+++ b/.github/workflows/ros-lint.yml
@@ -23,6 +23,8 @@ jobs:
         uses: ros-tooling/setup-ros@v0.7
 
       - name: Run Linter
+        env:
+          AMENT_CPPCHECK_ALLOW_SLOW_VERSIONS: 1
         uses: ros-tooling/action-ros-lint@master
         with:
           linter: ${{ matrix.linter }}

--- a/.github/workflows/ros-lint.yml
+++ b/.github/workflows/ros-lint.yml
@@ -1,4 +1,4 @@
-# The name of the workflow 
+# The name of the workflow
 name: Lint
 
 # Specifies the events that trigger the workflow

--- a/.github/workflows/ros-lint.yml
+++ b/.github/workflows/ros-lint.yml
@@ -1,0 +1,30 @@
+# The name of the workflow 
+name: Lint
+
+# Specifies the events that trigger the workflow
+on:
+  pull_request:
+
+# Defines a set of jobs to be run as part of the workflow
+jobs:
+  ament_lint:
+    runs-on: ubuntu-latest
+    container:
+      image: rostooling/setup-ros-docker:ubuntu-noble-ros-rolling-ros-base-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        linter: [cppcheck, cpplint, uncrustify, flake8, pep257, lint_cmake, xmllint, copyright]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup ROS environment
+        uses: ros-tooling/setup-ros@v0.7
+
+      - name: Run Linter
+        uses: ros-tooling/action-ros-lint@master
+        with:
+          linter: ${{ matrix.linter }}
+          distribution: rolling
+          package-name: "*"

--- a/.github/workflows/ros-lint.yml
+++ b/.github/workflows/ros-lint.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        linter: [cppcheck, cpplint, uncrustify, flake8, pep257, lint_cmake, xmllint, copyright]
+        linter: [cppcheck, cpplint, flake8, pep257, lint_cmake, xmllint, copyright]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/turtlebot3_fake_node/include/turtlebot3_fake_node/turtlebot3_fake_node.hpp
+++ b/turtlebot3_fake_node/include/turtlebot3_fake_node/turtlebot3_fake_node.hpp
@@ -18,9 +18,9 @@
 #define TURTLEBOT3_FAKE_NODE__TURTLEBOT3_FAKE_NODE_HPP_
 
 #include <tf2/LinearMath/Quaternion.h>
-#include <rclcpp/rclcpp.hpp>
 #include <chrono>
 
+#include <rclcpp/rclcpp.hpp>
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include "geometry_msgs/msg/twist.hpp"
 #include "nav_msgs/msg/odometry.hpp"

--- a/turtlebot3_gazebo/include/turtlebot3_gazebo/turtlebot3_drive.hpp
+++ b/turtlebot3_gazebo/include/turtlebot3_gazebo/turtlebot3_drive.hpp
@@ -17,12 +17,12 @@
 #ifndef TURTLEBOT3_GAZEBO__TURTLEBOT3_DRIVE_HPP_
 #define TURTLEBOT3_GAZEBO__TURTLEBOT3_DRIVE_HPP_
 
+#include <tf2/LinearMath/Matrix3x3.h>
+#include <tf2/LinearMath/Quaternion.h>
 #include <geometry_msgs/msg/twist.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/laser_scan.hpp>
-#include <tf2/LinearMath/Matrix3x3.h>
-#include <tf2/LinearMath/Quaternion.h>
 
 #define DEG2RAD (M_PI / 180.0)
 #define RAD2DEG (180.0 / M_PI)

--- a/turtlebot3_gazebo/launch/multi_robot.launch.py
+++ b/turtlebot3_gazebo/launch/multi_robot.launch.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Authors: Joep Tool, HyunGyu Kim
+# Authors: Joep Tool, HyunGyu
 
 import os
 

--- a/turtlebot3_gazebo/launch/multi_robot.launch.py
+++ b/turtlebot3_gazebo/launch/multi_robot.launch.py
@@ -17,15 +17,17 @@
 # Authors: Joep Tool, HyunGyu
 
 import os
+import xml.etree.ElementTree as ET
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import GroupAction, IncludeLaunchDescription, RegisterEventHandler
-from launch_ros.actions import PushRosNamespace
+from launch.actions import GroupAction
+from launch.actions import IncludeLaunchDescription
+from launch.actions import RegisterEventHandler
 from launch.event_handlers import OnShutdown
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
-import xml.etree.ElementTree as ET
+from launch_ros.actions import PushRosNamespace
 
 
 def generate_launch_description():
@@ -92,11 +94,11 @@ def generate_launch_description():
         tree = ET.parse(urdf_path)
         root = tree.getroot()
         for odom_frame_tag in root.iter('odometry_frame'):
-            odom_frame_tag.text = f"{namespace}_{count+1}/odom"
+            odom_frame_tag.text = f'{namespace}_{count+1}/odom'
         for base_frame_tag in root.iter('robot_base_frame'):
-            base_frame_tag.text = f"{namespace}_{count+1}/base_footprint"
+            base_frame_tag.text = f'{namespace}_{count+1}/base_footprint'
         for scan_frame_tag in root.iter('frame_name'):
-            scan_frame_tag.text = f"{namespace}_{count+1}/base_scan"
+            scan_frame_tag.text = f'{namespace}_{count+1}/base_scan'
         urdf_modified = ET.tostring(tree.getroot(), encoding='unicode')
         urdf_modified = '<?xml version="1.0" ?>\n'+urdf_modified
         with open(f'{save_path}{count+1}.sdf', 'w') as file:

--- a/turtlebot3_gazebo/launch/multi_robot.launch.py
+++ b/turtlebot3_gazebo/launch/multi_robot.launch.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+#
+# Copyright 2019 ROBOTIS CO., LTD.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors: Joep Tool, HyunGyu Kim
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import GroupAction, IncludeLaunchDescription, RegisterEventHandler
+from launch_ros.actions import PushRosNamespace
+from launch.event_handlers import OnShutdown
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+import xml.etree.ElementTree as ET
+
+
+def generate_launch_description():
+    TURTLEBOT3_MODEL = os.environ['TURTLEBOT3_MODEL']
+
+    number_of_robots = 4
+    namespace = 'TB3'
+    pose = [[-2, -0.5], [0.5, -2], [2, 0.5], [-0.5, 2]]
+    model_folder = 'turtlebot3_' + TURTLEBOT3_MODEL
+    urdf_path = os.path.join(
+        get_package_share_directory('turtlebot3_gazebo'),
+        'models',
+        model_folder,
+        'model.sdf'
+    )
+    save_path = os.path.join(
+        get_package_share_directory('turtlebot3_gazebo'),
+        'models',
+        model_folder,
+        'tmp'
+    )
+    launch_file_dir = os.path.join(get_package_share_directory('turtlebot3_gazebo'), 'launch')
+    pkg_gazebo_ros = get_package_share_directory('gazebo_ros')
+
+    use_sim_time = LaunchConfiguration('use_sim_time', default='false')
+
+    world = os.path.join(
+        get_package_share_directory('turtlebot3_gazebo'),
+        'worlds',
+        'turtlebot3_world.world'
+    )
+
+    gzserver_cmd = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(pkg_gazebo_ros, 'launch', 'gzserver.launch.py')
+        ),
+        launch_arguments={'world': world}.items()
+    )
+
+    gzclient_cmd = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(pkg_gazebo_ros, 'launch', 'gzclient.launch.py')
+        )
+    )
+
+    robot_state_publisher_cmd_list = []
+
+    for count in range(number_of_robots):
+        robot_state_publisher_cmd_list.append(
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource(
+                    os.path.join(launch_file_dir, 'robot_state_publisher.launch.py')
+                ),
+                launch_arguments={
+                    'use_sim_time': use_sim_time,
+                    'frame_prefix': f'{namespace}_{count+1}'
+                    }.items()
+            )
+        )
+
+    spawn_turtlebot_cmd_list = []
+
+    for count in range(number_of_robots):
+        tree = ET.parse(urdf_path)
+        root = tree.getroot()
+        for odom_frame_tag in root.iter('odometry_frame'):
+            odom_frame_tag.text = f"{namespace}_{count+1}/odom"
+        for base_frame_tag in root.iter('robot_base_frame'):
+            base_frame_tag.text = f"{namespace}_{count+1}/base_footprint"
+        for scan_frame_tag in root.iter('frame_name'):
+            scan_frame_tag.text = f"{namespace}_{count+1}/base_scan"
+        urdf_modified = ET.tostring(tree.getroot(), encoding='unicode')
+        urdf_modified = '<?xml version="1.0" ?>\n'+urdf_modified
+        with open(f'{save_path}{count+1}.sdf', 'w') as file:
+            file.write(urdf_modified)
+
+        spawn_turtlebot_cmd_list.append(
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource(
+                    os.path.join(launch_file_dir, 'multi_spawn_turtlebot3.launch.py')
+                ),
+                launch_arguments={
+                        'x_pose': str(pose[count][0]),
+                        'y_pose': str(pose[count][1]),
+                        'robot_name': f'{TURTLEBOT3_MODEL}_{count+1}',
+                        'namespace': f'{namespace}_{count+1}',
+                        'sdf_path': f'{save_path}{count+1}.sdf'
+                }.items()
+            )
+        )
+
+    ld = LaunchDescription()
+    # Add the commands to the launch description
+    ld.add_action(gzserver_cmd)
+    ld.add_action(gzclient_cmd)
+    ld.add_action(RegisterEventHandler(
+        OnShutdown(
+            on_shutdown=lambda event,
+            context: [os.remove(f'{save_path}{count+1}.sdf') for count in range(number_of_robots)]
+        )
+    ))
+    for count, spawn_turtlebot_cmd in enumerate(spawn_turtlebot_cmd_list, start=1):
+        ld.add_action(GroupAction([PushRosNamespace(f'{namespace}_{count}'),
+                                  robot_state_publisher_cmd_list[count-1],
+                                  spawn_turtlebot_cmd]))
+
+    return ld

--- a/turtlebot3_gazebo/launch/multi_spawn_turtlebot3.launch.py
+++ b/turtlebot3_gazebo/launch/multi_spawn_turtlebot3.launch.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    TURTLEBOT3_MODEL = os.environ['TURTLEBOT3_MODEL']
+
+    # Launch configuration variables specific to simulation
+    x_pose = LaunchConfiguration('x_pose', default='0.0')
+    y_pose = LaunchConfiguration('y_pose', default='0.0')
+    robot_name = LaunchConfiguration('robot_name', default=TURTLEBOT3_MODEL)
+    namespace = LaunchConfiguration('namespace', default='')
+    sdf_path = LaunchConfiguration('sdf_path', default='')
+
+    declare_x_position_cmd = DeclareLaunchArgument(
+        'x_pose', default_value='0.0',
+        description='Specify namespace of the robot')
+
+    declare_y_position_cmd = DeclareLaunchArgument(
+        'y_pose', default_value='0.0',
+        description='Specify namespace of the robot')
+    start_gazebo_ros_spawner_cmd = Node(
+        package='gazebo_ros',
+        executable='spawn_entity.py',
+        arguments=[
+            '-entity', robot_name,
+            '-file', sdf_path,
+            '-x', x_pose,
+            '-y', y_pose,
+            '-z', '0.01',
+            '-robot_namespace', namespace
+        ],
+        output='screen',
+    )
+
+    ld = LaunchDescription()
+
+    # Declare the launch options
+    ld.add_action(declare_x_position_cmd)
+    ld.add_action(declare_y_position_cmd)
+    # Add any conditioned actions
+    ld.add_action(start_gazebo_ros_spawner_cmd)
+    return ld

--- a/turtlebot3_gazebo/launch/multi_spawn_turtlebot3.launch.py
+++ b/turtlebot3_gazebo/launch/multi_spawn_turtlebot3.launch.py
@@ -26,7 +26,6 @@ from launch_ros.actions import Node
 def generate_launch_description():
     TURTLEBOT3_MODEL = os.environ['TURTLEBOT3_MODEL']
 
-    # Launch configuration variables specific to simulation
     x_pose = LaunchConfiguration('x_pose', default='0.0')
     y_pose = LaunchConfiguration('y_pose', default='0.0')
     robot_name = LaunchConfiguration('robot_name', default=TURTLEBOT3_MODEL)
@@ -55,10 +54,7 @@ def generate_launch_description():
     )
 
     ld = LaunchDescription()
-
-    # Declare the launch options
     ld.add_action(declare_x_position_cmd)
     ld.add_action(declare_y_position_cmd)
-    # Add any conditioned actions
     ld.add_action(start_gazebo_ros_spawner_cmd)
     return ld

--- a/turtlebot3_gazebo/launch/multi_spawn_turtlebot3.launch.py
+++ b/turtlebot3_gazebo/launch/multi_spawn_turtlebot3.launch.py
@@ -12,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# Authors: HyunGyu
 
 import os
 

--- a/turtlebot3_gazebo/launch/robot_state_publisher.launch.py
+++ b/turtlebot3_gazebo/launch/robot_state_publisher.launch.py
@@ -21,15 +21,16 @@ import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, PythonExpression
 from launch_ros.actions import Node
 
 
 def generate_launch_description():
     TURTLEBOT3_MODEL = os.environ['TURTLEBOT3_MODEL']
 
-    use_sim_time = LaunchConfiguration('use_sim_time', default='false')
+    use_sim_time = LaunchConfiguration('use_sim_time', default='true')
     urdf_file_name = 'turtlebot3_' + TURTLEBOT3_MODEL + '.urdf'
+    frame_prefix = LaunchConfiguration('frame_prefix', default='')
 
     print('urdf_file_name : {}'.format(urdf_file_name))
 
@@ -46,7 +47,6 @@ def generate_launch_description():
             'use_sim_time',
             default_value='false',
             description='Use simulation (Gazebo) clock if true'),
-
         Node(
             package='robot_state_publisher',
             executable='robot_state_publisher',
@@ -54,7 +54,8 @@ def generate_launch_description():
             output='screen',
             parameters=[{
                 'use_sim_time': use_sim_time,
-                'robot_description': robot_desc
+                'robot_description': robot_desc,
+                'frame_prefix': PythonExpression(["'", frame_prefix, "/'"])
             }],
         ),
     ])

--- a/turtlebot3_gazebo/models/turtlebot3_dqn_world/obstacle_plugin/obstacle1.cc
+++ b/turtlebot3_gazebo/models/turtlebot3_dqn_world/obstacle_plugin/obstacle1.cc
@@ -14,9 +14,9 @@
 //
 // Author: Ryan Shim
 
-#include <ignition/math.hh>
 #include <stdio.h>
 
+#include <ignition/math.hh>
 #include <gazebo/common/common.hh>
 #include <gazebo/gazebo.hh>
 #include <gazebo/physics/physics.hh>
@@ -24,70 +24,70 @@
 
 namespace gazebo
 {
-class Obstacle1: public ModelPlugin
-{
-public:
-  void Load(physics::ModelPtr _parent, sdf::ElementPtr /*_sdf*/)
+  class Obstacle1: public ModelPlugin
   {
-    // Store the pointer to the model
-    this->model = _parent;
+public:
+    void Load(physics::ModelPtr _parent, sdf::ElementPtr /*_sdf*/)
+    {
+      // Store the pointer to the model
+      this->model = _parent;
 
-    // create the animation
-    gazebo::common::PoseAnimationPtr anim(
-      // name the animation "move_1",
-      // make it last 260 seconds,
-      // and set it on a repeat loop
-      new gazebo::common::PoseAnimation("move1", 160.0, true));
+      // create the animation
+      gazebo::common::PoseAnimationPtr anim(
+        // name the animation "move_1",
+        // make it last 260 seconds,
+        // and set it on a repeat loop
+        new gazebo::common::PoseAnimation("move1", 160.0, true));
 
-    gazebo::common::PoseKeyFrame * key;
+      gazebo::common::PoseKeyFrame * key;
 
-    // set starting location of the box
-    key = anim->CreateKeyFrame(0);
-    key->Translation(ignition::math::Vector3d(0.0, 0.0, 0.0));
-    key->Rotation(ignition::math::Quaterniond(0, 0, 0));
+      // set starting location of the box
+      key = anim->CreateKeyFrame(0);
+      key->Translation(ignition::math::Vector3d(0.0, 0.0, 0.0));
+      key->Rotation(ignition::math::Quaterniond(0, 0, 0));
 
-    key = anim->CreateKeyFrame(10);
-    key->Translation(ignition::math::Vector3d(-0.5, -1.0, 0.0));
-    key->Rotation(ignition::math::Quaterniond(0, 0, 0));
+      key = anim->CreateKeyFrame(10);
+      key->Translation(ignition::math::Vector3d(-0.5, -1.0, 0.0));
+      key->Rotation(ignition::math::Quaterniond(0, 0, 0));
 
-    key = anim->CreateKeyFrame(50);
-    key->Translation(ignition::math::Vector3d(-3.5, -1.0, 0.0));
-    key->Rotation(ignition::math::Quaterniond(0, 0, 0));
+      key = anim->CreateKeyFrame(50);
+      key->Translation(ignition::math::Vector3d(-3.5, -1.0, 0.0));
+      key->Rotation(ignition::math::Quaterniond(0, 0, 0));
 
-    key = anim->CreateKeyFrame(70);
-    key->Translation(ignition::math::Vector3d(-3.7, -3.0, 0.0));
-    key->Rotation(ignition::math::Quaterniond(0, 0, 0));
+      key = anim->CreateKeyFrame(70);
+      key->Translation(ignition::math::Vector3d(-3.7, -3.0, 0.0));
+      key->Rotation(ignition::math::Quaterniond(0, 0, 0));
 
-    key = anim->CreateKeyFrame(90);
-    key->Translation(ignition::math::Vector3d(-3.5, -1.0, 0.0));
-    key->Rotation(ignition::math::Quaterniond(0, 0, 0));
+      key = anim->CreateKeyFrame(90);
+      key->Translation(ignition::math::Vector3d(-3.5, -1.0, 0.0));
+      key->Rotation(ignition::math::Quaterniond(0, 0, 0));
 
-    key = anim->CreateKeyFrame(130);
-    key->Translation(ignition::math::Vector3d(-0.5, -1.0, 0.0));
-    key->Rotation(ignition::math::Quaterniond(0, 0, 0));
+      key = anim->CreateKeyFrame(130);
+      key->Translation(ignition::math::Vector3d(-0.5, -1.0, 0.0));
+      key->Rotation(ignition::math::Quaterniond(0, 0, 0));
 
-    key = anim->CreateKeyFrame(140);
-    key->Translation(ignition::math::Vector3d(0.0, 0.0, 0.0));
-    key->Rotation(ignition::math::Quaterniond(0, 0, 0));
+      key = anim->CreateKeyFrame(140);
+      key->Translation(ignition::math::Vector3d(0.0, 0.0, 0.0));
+      key->Rotation(ignition::math::Quaterniond(0, 0, 0));
 
-    key = anim->CreateKeyFrame(160);
-    key->Translation(ignition::math::Vector3d(0.0, 0.0, 0.0));
-    key->Rotation(ignition::math::Quaterniond(0, 0, 0));
+      key = anim->CreateKeyFrame(160);
+      key->Translation(ignition::math::Vector3d(0.0, 0.0, 0.0));
+      key->Rotation(ignition::math::Quaterniond(0, 0, 0));
 
-    // set the animation
-    _parent->SetAnimation(anim);
-  }
+      // set the animation
+      _parent->SetAnimation(anim);
+    }
 
-// Pointer to the model
+    // Pointer to the model
 
 private:
-  physics::ModelPtr model;
+    physics::ModelPtr model;
 
 // Pointer to the update event connection
 
 private:
-  event::ConnectionPtr updateConnection;
-};
-// Register this plugin with the simulator
-GZ_REGISTER_MODEL_PLUGIN(Obstacle1)
+    event::ConnectionPtr updateConnection;
+  };
+  // Register this plugin with the simulator
+  GZ_REGISTER_MODEL_PLUGIN(Obstacle1)
 }  // namespace gazebo

--- a/turtlebot3_gazebo/models/turtlebot3_dqn_world/obstacle_plugin/obstacle1.cc
+++ b/turtlebot3_gazebo/models/turtlebot3_dqn_world/obstacle_plugin/obstacle1.cc
@@ -88,4 +88,4 @@ private:
 };
 // Register this plugin with the simulator
 GZ_REGISTER_MODEL_PLUGIN(Obstacle1)
-}// namespace gazebo
+}  // namespace gazebo

--- a/turtlebot3_gazebo/models/turtlebot3_dqn_world/obstacle_plugin/obstacle2.cc
+++ b/turtlebot3_gazebo/models/turtlebot3_dqn_world/obstacle_plugin/obstacle2.cc
@@ -104,4 +104,4 @@ private:
 };
 // Register this plugin with the simulator
 GZ_REGISTER_MODEL_PLUGIN(Obstacle2)
-}// namespace gazebo
+}  // namespace gazebo

--- a/turtlebot3_gazebo/models/turtlebot3_dqn_world/obstacle_plugin/obstacle2.cc
+++ b/turtlebot3_gazebo/models/turtlebot3_dqn_world/obstacle_plugin/obstacle2.cc
@@ -14,9 +14,9 @@
 //
 // Author: Ryan Shim
 
-#include <ignition/math.hh>
 #include <stdio.h>
 
+#include <ignition/math.hh>
 #include <gazebo/common/common.hh>
 #include <gazebo/gazebo.hh>
 #include <gazebo/physics/physics.hh>
@@ -24,86 +24,85 @@
 
 namespace gazebo
 {
-class Obstacle2: public ModelPlugin
-{
-public:
-  void Load(physics::ModelPtr _parent, sdf::ElementPtr /*_sdf*/)
+  class Obstacle2: public ModelPlugin
   {
-    // Store the pointer to the model
-    this->model = _parent;
+public:
+    void Load(physics::ModelPtr _parent, sdf::ElementPtr /*_sdf*/)
+    {
+      // Store the pointer to the model
+      this->model = _parent;
 
-    // create the animation
-    gazebo::common::PoseAnimationPtr anim(
-      // name the animation "move_2",
-      // make it last 260 seconds,
-      // and set it on a repeat loop
-      new gazebo::common::PoseAnimation("move2", 140.0, true));
+      // create the animation
+      gazebo::common::PoseAnimationPtr anim(
+        // name the animation "move_2",
+        // make it last 260 seconds,
+        // and set it on a repeat loop
+        new gazebo::common::PoseAnimation("move2", 140.0, true));
 
-    gazebo::common::PoseKeyFrame * key;
+      gazebo::common::PoseKeyFrame * key;
 
-    // set starting location of the box
-    key = anim->CreateKeyFrame(0);
-    key->Translation(ignition::math::Vector3d(0.0, 0.0, 0.0));
-    key->Rotation(ignition::math::Quaterniond(0, 0, 0));
+      // set starting location of the box
+      key = anim->CreateKeyFrame(0);
+      key->Translation(ignition::math::Vector3d(0.0, 0.0, 0.0));
+      key->Rotation(ignition::math::Quaterniond(0, 0, 0));
 
-    key = anim->CreateKeyFrame(10);
-    key->Translation(ignition::math::Vector3d(0.7, 0.2, 0.0));
-    key->Rotation(ignition::math::Quaterniond(0, 0, 0));
+      key = anim->CreateKeyFrame(10);
+      key->Translation(ignition::math::Vector3d(0.7, 0.2, 0.0));
+      key->Rotation(ignition::math::Quaterniond(0, 0, 0));
 
-    key = anim->CreateKeyFrame(40);
-    key->Translation(ignition::math::Vector3d(2.5, 3.5, 0.0));
-    key->Rotation(ignition::math::Quaterniond(0, 0, 0));
+      key = anim->CreateKeyFrame(40);
+      key->Translation(ignition::math::Vector3d(2.5, 3.5, 0.0));
+      key->Rotation(ignition::math::Quaterniond(0, 0, 0));
 
-    key = anim->CreateKeyFrame(55);
-    key->Translation(ignition::math::Vector3d(0.3, 3.5, 0.0));
-    key->Rotation(ignition::math::Quaterniond(0, 0, 0));
+      key = anim->CreateKeyFrame(55);
+      key->Translation(ignition::math::Vector3d(0.3, 3.5, 0.0));
+      key->Rotation(ignition::math::Quaterniond(0, 0, 0));
 
-    key = anim->CreateKeyFrame(85);
-    key->Translation(ignition::math::Vector3d(3.5, 1.8, 0.0));
-    key->Rotation(ignition::math::Quaterniond(0, 0, 0));
+      key = anim->CreateKeyFrame(85);
+      key->Translation(ignition::math::Vector3d(3.5, 1.8, 0.0));
+      key->Rotation(ignition::math::Quaterniond(0, 0, 0));
 
-    key = anim->CreateKeyFrame(100);
-    key->Translation(ignition::math::Vector3d(3.5, 0.0, 0.0));
-    key->Rotation(ignition::math::Quaterniond(0, 0, 0));
+      key = anim->CreateKeyFrame(100);
+      key->Translation(ignition::math::Vector3d(3.5, 0.0, 0.0));
+      key->Rotation(ignition::math::Quaterniond(0, 0, 0));
 
-    key = anim->CreateKeyFrame(110);
-    key->Translation(ignition::math::Vector3d(2.0, 0.5, 0.0));
-    key->Rotation(ignition::math::Quaterniond(0, 0, 0));
+      key = anim->CreateKeyFrame(110);
+      key->Translation(ignition::math::Vector3d(2.0, 0.5, 0.0));
+      key->Rotation(ignition::math::Quaterniond(0, 0, 0));
 
-    key = anim->CreateKeyFrame(115);
-    key->Translation(ignition::math::Vector3d(1.5, 1.0, 0.0));
-    key->Rotation(ignition::math::Quaterniond(0, 0, 0));
+      key = anim->CreateKeyFrame(115);
+      key->Translation(ignition::math::Vector3d(1.5, 1.0, 0.0));
+      key->Rotation(ignition::math::Quaterniond(0, 0, 0));
 
-    key = anim->CreateKeyFrame(120);
-    key->Translation(ignition::math::Vector3d(1.0, 0.5, 0.0));
-    key->Rotation(ignition::math::Quaterniond(0, 0, 0));
+      key = anim->CreateKeyFrame(120);
+      key->Translation(ignition::math::Vector3d(1.0, 0.5, 0.0));
+      key->Rotation(ignition::math::Quaterniond(0, 0, 0));
 
-    key = anim->CreateKeyFrame(125);
-    key->Translation(ignition::math::Vector3d(0.5, 0.1, 0.0));
-    key->Rotation(ignition::math::Quaterniond(0, 0, 0));
+      key = anim->CreateKeyFrame(125);
+      key->Translation(ignition::math::Vector3d(0.5, 0.1, 0.0));
+      key->Rotation(ignition::math::Quaterniond(0, 0, 0));
 
-    key = anim->CreateKeyFrame(130);
-    key->Translation(ignition::math::Vector3d(0.0, 0.0, 0.0));
-    key->Rotation(ignition::math::Quaterniond(0, 0, 0));
+      key = anim->CreateKeyFrame(130);
+      key->Translation(ignition::math::Vector3d(0.0, 0.0, 0.0));
+      key->Rotation(ignition::math::Quaterniond(0, 0, 0));
 
-    key = anim->CreateKeyFrame(140);
-    key->Translation(ignition::math::Vector3d(0.0, 0.0, 0.0));
-    key->Rotation(ignition::math::Quaterniond(0, 0, 0));
+      key = anim->CreateKeyFrame(140);
+      key->Translation(ignition::math::Vector3d(0.0, 0.0, 0.0));
+      key->Rotation(ignition::math::Quaterniond(0, 0, 0));
 
-    // set the animation
-    _parent->SetAnimation(anim);
-  }
+      // set the animation
+      _parent->SetAnimation(anim);
+    }
 
-// Pointer to the model
-
-private:
-  physics::ModelPtr model;
-
-// Pointer to the update event connection
+    // Pointer to the model
 
 private:
-  event::ConnectionPtr updateConnection;
-};
-// Register this plugin with the simulator
-GZ_REGISTER_MODEL_PLUGIN(Obstacle2)
+    physics::ModelPtr model;
+    // Pointer to the update event connection
+
+private:
+    event::ConnectionPtr updateConnection;
+  };
+  // Register this plugin with the simulator
+  GZ_REGISTER_MODEL_PLUGIN(Obstacle2)
 }  // namespace gazebo

--- a/turtlebot3_gazebo/models/turtlebot3_dqn_world/obstacle_plugin/obstacles.cc
+++ b/turtlebot3_gazebo/models/turtlebot3_dqn_world/obstacle_plugin/obstacles.cc
@@ -14,9 +14,9 @@
 //
 // Author: Ryan Shim
 
-#include <ignition/math.hh>
 #include <stdio.h>
 
+#include <ignition/math.hh>
 #include <gazebo/common/common.hh>
 #include <gazebo/gazebo.hh>
 #include <gazebo/physics/physics.hh>
@@ -26,50 +26,49 @@
 
 namespace gazebo
 {
-class Obstacles: public ModelPlugin
-{
-public:
-  void Load(physics::ModelPtr _parent, sdf::ElementPtr /*_sdf*/)
+  class Obstacles: public ModelPlugin
   {
-    // Store the pointer to the model
-    this->model = _parent;
+public:
+    void Load(physics::ModelPtr _parent, sdf::ElementPtr /*_sdf*/)
+    {
+      // Store the pointer to the model
+      this->model = _parent;
 
-    // create the animation
-    gazebo::common::PoseAnimationPtr anim(
-      // name the animation "move",
-      // make it last 40 seconds,
-      // and set it on a repeat loop
-      new gazebo::common::PoseAnimation("move", 40.0, true));
+      // create the animation
+      gazebo::common::PoseAnimationPtr anim(
+        // name the animation "move",
+        // make it last 40 seconds,
+        // and set it on a repeat loop
+        new gazebo::common::PoseAnimation("move", 40.0, true));
 
-    gazebo::common::PoseKeyFrame * key;
+      gazebo::common::PoseKeyFrame * key;
 
-    // set starting location of the box
-    key = anim->CreateKeyFrame(0);
-    key->Translation(ignition::math::Vector3d(0.0, 0.0, 0.0));
-    key->Rotation(ignition::math::Quaterniond(0, 0, 0));
+      // set starting location of the box
+      key = anim->CreateKeyFrame(0);
+      key->Translation(ignition::math::Vector3d(0.0, 0.0, 0.0));
+      key->Rotation(ignition::math::Quaterniond(0, 0, 0));
 
-    key = anim->CreateKeyFrame(20);
-    key->Translation(ignition::math::Vector3d(0.0, 0.0, 0.0));
-    key->Rotation(ignition::math::Quaterniond(0, 0, PI));
+      key = anim->CreateKeyFrame(20);
+      key->Translation(ignition::math::Vector3d(0.0, 0.0, 0.0));
+      key->Rotation(ignition::math::Quaterniond(0, 0, PI));
 
-    key = anim->CreateKeyFrame(40);
-    key->Translation(ignition::math::Vector3d(0.0, 0.0, 0.0));
-    key->Rotation(ignition::math::Quaterniond(0, 0, 2 * PI));
+      key = anim->CreateKeyFrame(40);
+      key->Translation(ignition::math::Vector3d(0.0, 0.0, 0.0));
+      key->Rotation(ignition::math::Quaterniond(0, 0, 2 * PI));
 
-    // set the animation
-    _parent->SetAnimation(anim);
-  }
+      // set the animation
+      _parent->SetAnimation(anim);
+    }
 
-// Pointer to the model
-
-private:
-  physics::ModelPtr model;
-
-// Pointer to the update event connection
+    // Pointer to the model
 
 private:
-  event::ConnectionPtr updateConnection;
-};
+    physics::ModelPtr model;
+    // Pointer to the update event connection
+
+private:
+    event::ConnectionPtr updateConnection;
+  };
 // Register this plugin with the simulator
-GZ_REGISTER_MODEL_PLUGIN(Obstacles)
+  GZ_REGISTER_MODEL_PLUGIN(Obstacles)
 }  // namespace gazebo

--- a/turtlebot3_gazebo/models/turtlebot3_dqn_world/obstacle_plugin/obstacles.cc
+++ b/turtlebot3_gazebo/models/turtlebot3_dqn_world/obstacle_plugin/obstacles.cc
@@ -70,4 +70,4 @@ private:
 };
 // Register this plugin with the simulator
 GZ_REGISTER_MODEL_PLUGIN(Obstacles)
-}// namespace gazebo
+}  // namespace gazebo

--- a/turtlebot3_gazebo/package.xml
+++ b/turtlebot3_gazebo/package.xml
@@ -13,6 +13,7 @@
   <url type="bugtracker">https://github.com/ROBOTIS-GIT/turtlebot3_simulations/issues</url>
   <author email="thlim@robotis.com">Darby Lim</author>
   <author email="pyo@robotis.com">Pyo</author>
+  <author email="kimhg@robotis.com">Hyungyu</author>
   <author>Ryan Shim</author>
   <buildtool_depend>ament_cmake</buildtool_depend>
   <depend>gazebo_ros_pkgs</depend>

--- a/turtlebot3_simulations_ci.repos
+++ b/turtlebot3_simulations_ci.repos
@@ -2,16 +2,16 @@ repositories:
   turtlebot3/turtlebot3:
     type: git
     url: https://github.com/ROBOTIS-GIT/turtlebot3.git
-    version: ros2-devel
+    version: main
   turtlebot3/turtlebot3_msgs:
     type: git
     url: https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git
-    version: ros2-devel
+    version: main
   utils/DynamixelSDK:
     type: git
     url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
-    version: ros2-devel
+    version: main
   utils/hls_lfcd_lds_driver:
     type: git
     url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git
-    version: ros2-devel
+    version: main

--- a/turtlebot3_simulations_ci.repos
+++ b/turtlebot3_simulations_ci.repos
@@ -10,7 +10,7 @@ repositories:
   utils/DynamixelSDK:
     type: git
     url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
-    version: main
+    version: humble
   utils/hls_lfcd_lds_driver:
     type: git
     url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git


### PR DESCRIPTION
## Description
This pull request merges the `feature-multi-robots-control-in-gazebo` branch into the main branch, using multi robots launch to spawn multi robots in gazebo and control with namespace. This change in this branch makes user use multiple turtlebot3s in gazebo that have identical topics and frames.

## Summary of Changes
- Add `multi_robot.launch.py`
  -  This launch spawn multiple turtlebot3s in gazebo and user  can modify the launch file to change map or position of turtlebot3s.
- Add 'multi_spawn_turtlebot3.launch.py'
  -   It makes turtlebots be spawned with separate namespace.
- Add namespace argument in`robot_state_publisher.launch.py`
  - It adds a prefix to the robot state frames (e.g., base_link, imu_link, etc.)
 
## Motivation
 There are some Issue regarding the use of namespace in gazebo. Also it has the potential to evolve into examples such as multi-robot navigation in the future.

## Testing & Validation
This branch has been validated on the Local PC with the Humble version and works properly

## Operation
<details>
  <summary>Picture</summary>

  - ![p1](https://github.com/user-attachments/assets/6d756942-9532-4dcf-ae60-028c498af228) 

  - ![p2](https://github.com/user-attachments/assets/15c564a8-982a-4a17-a8af-47f53938e378)  

  - ![p3](https://github.com/user-attachments/assets/b945a75a-8c66-4765-b233-e0a77173b938)  
 
  - ![p4](https://github.com/user-attachments/assets/1abac35b-de35-45e9-bf87-e7fdb605bc6d)  
 
</details>
