### PR TITLE
Fix buildfarm error in rolling

### DIFF
--- a/turtlebot3_fake_node/CHANGELOG.rst
+++ b/turtlebot3_fake_node/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package turtlebot3_fake
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.3.7 (2025-06-27)
+------------------
+* Changed the header files in tf2/LinearMath from .h to .hpp
+* Contributors: Hyungyu Kim
+
 2.3.5 (2025-06-04)
 ------------------
 * None

--- a/turtlebot3_fake_node/include/turtlebot3_fake_node/turtlebot3_fake_node.hpp
+++ b/turtlebot3_fake_node/include/turtlebot3_fake_node/turtlebot3_fake_node.hpp
@@ -17,7 +17,7 @@
 #ifndef TURTLEBOT3_FAKE_NODE__TURTLEBOT3_FAKE_NODE_HPP_
 #define TURTLEBOT3_FAKE_NODE__TURTLEBOT3_FAKE_NODE_HPP_
 
-#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Quaternion.hpp>
 #include <chrono>
 
 #include <rclcpp/rclcpp.hpp>

--- a/turtlebot3_fake_node/include/turtlebot3_fake_node/turtlebot3_fake_node.hpp
+++ b/turtlebot3_fake_node/include/turtlebot3_fake_node/turtlebot3_fake_node.hpp
@@ -17,7 +17,6 @@
 #ifndef TURTLEBOT3_FAKE_NODE__TURTLEBOT3_FAKE_NODE_HPP_
 #define TURTLEBOT3_FAKE_NODE__TURTLEBOT3_FAKE_NODE_HPP_
 
-#include <tf2/LinearMath/Quaternion.hpp>
 #include <chrono>
 
 #include <rclcpp/rclcpp.hpp>
@@ -25,6 +24,7 @@
 #include "geometry_msgs/msg/twist.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "sensor_msgs/msg/joint_state.hpp"
+#include <tf2/LinearMath/Quaternion.hpp>
 #include "tf2_msgs/msg/tf_message.hpp"
 #include "turtlebot3_msgs/msg/sensor_state.hpp"
 

--- a/turtlebot3_fake_node/package.xml
+++ b/turtlebot3_fake_node/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>turtlebot3_fake_node</name>
-  <version>2.3.5</version>
+  <version>2.3.7</version>
   <description>
     Package for TurtleBot3 fake node. With this package, simple tests can be done without a robot.
     You can do simple tests using this package on rviz without real robots.

--- a/turtlebot3_gazebo/CHANGELOG.rst
+++ b/turtlebot3_gazebo/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package turtlebot3_gazebo
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.3.7 (2025-06-27)
+------------------
+* Changed the header files in tf2/LinearMath from .h to .hpp
+* Contributors: Hyungyu Kim
+
 2.3.5 (2025-06-04)
 ------------------
 * Added turtlebot3_machine_learning world and plugin

--- a/turtlebot3_gazebo/include/turtlebot3_gazebo/turtlebot3_drive.hpp
+++ b/turtlebot3_gazebo/include/turtlebot3_gazebo/turtlebot3_drive.hpp
@@ -17,8 +17,8 @@
 #ifndef TURTLEBOT3_GAZEBO__TURTLEBOT3_DRIVE_HPP_
 #define TURTLEBOT3_GAZEBO__TURTLEBOT3_DRIVE_HPP_
 
-#include <tf2/LinearMath/Matrix3x3.h>
-#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Matrix3x3.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
 #include <geometry_msgs/msg/twist.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <rclcpp/rclcpp.hpp>

--- a/turtlebot3_gazebo/include/turtlebot3_gazebo/turtlebot3_drive.hpp
+++ b/turtlebot3_gazebo/include/turtlebot3_gazebo/turtlebot3_drive.hpp
@@ -17,12 +17,12 @@
 #ifndef TURTLEBOT3_GAZEBO__TURTLEBOT3_DRIVE_HPP_
 #define TURTLEBOT3_GAZEBO__TURTLEBOT3_DRIVE_HPP_
 
-#include <tf2/LinearMath/Matrix3x3.hpp>
-#include <tf2/LinearMath/Quaternion.hpp>
 #include <geometry_msgs/msg/twist.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/laser_scan.hpp>
+#include <tf2/LinearMath/Matrix3x3.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
 
 #define DEG2RAD (M_PI / 180.0)
 #define RAD2DEG (180.0 / M_PI)

--- a/turtlebot3_gazebo/package.xml
+++ b/turtlebot3_gazebo/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>turtlebot3_gazebo</name>
-  <version>2.3.5</version>
+  <version>2.3.7</version>
   <description>
     Gazebo simulation package for the TurtleBot3
   </description>

--- a/turtlebot3_simulations/CHANGELOG.rst
+++ b/turtlebot3_simulations/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package turtlebot3_simulations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.3.7 (2025-06-27)
+------------------
+* Changed the header files in tf2/LinearMath from .h to .hpp
+* Contributors: Hyungyu Kim
+
 2.3.5 (2025-06-04)
 ------------------
 * Added turtlebot3_machine_learning world and plugin

--- a/turtlebot3_simulations/package.xml
+++ b/turtlebot3_simulations/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>turtlebot3_simulations</name>
-  <version>2.3.5</version>
+  <version>2.3.7</version>
   <description>
     ROS 2 packages for TurtleBot3 simulations
   </description>


### PR DESCRIPTION
In the Rolling version, the changes from [Deprecate C Headers (#720)](https://github.com/ros2/geometry2/pull/720) have been applied.