### PR TITLE
fix: correct fake node subscription type from twist to twist stamped

### DIFF
--- a/turtlebot3_fake_node/include/turtlebot3_fake_node/turtlebot3_fake_node.hpp
+++ b/turtlebot3_fake_node/include/turtlebot3_fake_node/turtlebot3_fake_node.hpp
@@ -21,7 +21,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include "geometry_msgs/msg/transform_stamped.hpp"
-#include "geometry_msgs/msg/twist.hpp"
+#include "geometry_msgs/msg/twist_stamped.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "sensor_msgs/msg/joint_state.hpp"
 #include <tf2/LinearMath/Quaternion.hpp>
@@ -51,7 +51,7 @@ private:
   rclcpp::Publisher<tf2_msgs::msg::TFMessage>::SharedPtr tf_pub_;
 
   // ROS topic subscribers
-  rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_sub_;
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr cmd_vel_sub_;
 
 
   nav_msgs::msg::Odometry odom_;
@@ -72,7 +72,7 @@ private:
   // Function prototypes
   void init_parameters();
   void init_variables();
-  void command_velocity_callback(const geometry_msgs::msg::Twist::SharedPtr cmd_vel_msg);
+  void command_velocity_callback(const geometry_msgs::msg::TwistStamped::SharedPtr cmd_vel_msg);
   void update_callback();
   bool update_odometry(const rclcpp::Duration & diff_time);
   void update_joint_state();

--- a/turtlebot3_fake_node/src/turtlebot3_fake_node.cpp
+++ b/turtlebot3_fake_node/src/turtlebot3_fake_node.cpp
@@ -45,7 +45,7 @@ Turtlebot3Fake::Turtlebot3Fake()
   tf_pub_ = this->create_publisher<tf2_msgs::msg::TFMessage>("tf", qos);
 
   // Initialise subscribers
-  cmd_vel_sub_ = this->create_subscription<geometry_msgs::msg::Twist>(
+  cmd_vel_sub_ = this->create_subscription<geometry_msgs::msg::TwistStamped>(
     "cmd_vel", \
     qos, \
     std::bind(
@@ -133,12 +133,12 @@ void Turtlebot3Fake::init_variables()
 ** Callback functions for ROS subscribers
 ********************************************************************************/
 void Turtlebot3Fake::command_velocity_callback(
-  const geometry_msgs::msg::Twist::SharedPtr cmd_vel_msg)
+  const geometry_msgs::msg::TwistStamped::SharedPtr cmd_vel_msg)
 {
   last_cmd_vel_time_ = this->now();
 
-  goal_linear_velocity_ = cmd_vel_msg->linear.x;
-  goal_angular_velocity_ = cmd_vel_msg->angular.z;
+  goal_linear_velocity_ = cmd_vel_msg->twist.linear.x;
+  goal_angular_velocity_ = cmd_vel_msg->twist.angular.z;
 
   wheel_speed_cmd_[LEFT] = goal_linear_velocity_ - (goal_angular_velocity_ * wheel_seperation_ / 2);
   wheel_speed_cmd_[RIGHT] = goal_linear_velocity_ + \


### PR DESCRIPTION
The fake node was incorrectly assigning the subscription type, which unabled the use of the teleop_keyboard from the jazzy based turtlebot3.
Signed-off-by: Elise Colin elise.col8@gmail.com