### PR TITLE
fix(gazebo): fix duplicate TF tree issue by removing unexpected trail…

### DIFF
--- a/turtlebot3_gazebo/launch/robot_state_publisher.launch.py
+++ b/turtlebot3_gazebo/launch/robot_state_publisher.launch.py
@@ -56,7 +56,7 @@ def generate_launch_description():
             parameters=[{
                 'use_sim_time': use_sim_time,
                 'robot_description': robot_desc,
-                'frame_prefix': PythonExpression(["'", frame_prefix, "/'"])
+                'frame_prefix': PythonExpression(["'", frame_prefix, "' + '/' if '", frame_prefix, "' != '' else ''"])
             }],
         ),
     ])

--- a/turtlebot3_gazebo/launch/robot_state_publisher.launch.py
+++ b/turtlebot3_gazebo/launch/robot_state_publisher.launch.py
@@ -56,7 +56,7 @@ def generate_launch_description():
             parameters=[{
                 'use_sim_time': use_sim_time,
                 'robot_description': robot_desc,
-                'frame_prefix': PythonExpression(["'", frame_prefix, "' + '/' if '", frame_prefix, "' != '' else ''"])
+                'frame_prefix': PythonExpression(["'", frame_prefix, "' + '/' if '", frame_prefix, "' != '' else ''"])
             }],
         ),
     ])


### PR DESCRIPTION
…ing slash in frame_prefix

### Description
In ROS 2, frame_ids do not start with a forward slash `/`. However, in `robot_state_publisher.launch.py`, `PythonExpression(["'", frame_prefix, "/'"])` forces `frame_prefix` to become `/` when no namespace is provided (since the default is `''`). 

This causes `robot_state_publisher` to broadcast frames with an unexpected leading slash (e.g., `/base_link`), resulting in unconnected double TF trees and warnings in visualization tools like Foxglove Studio, and potential `tf2::LookupException` in Nav2.

###🗣️ Fix
Modified the `frame_prefix` evaluation to avoid appending the trailing slash when `frame_prefix` is empty.